### PR TITLE
Fix/housekeeping

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -889,7 +889,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = @PROJECT_SOURCE_DIR@/doc/front.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ smoothG [![Build Status](https://travis-ci.org/LLNL/smoothG.svg?branch=master)](
 
 Mixed graph-Laplacian upscaling and solvers.
 
-For installation instructions, see INSTALL.md.
+For installation instructions, see [INSTALL.md](INSTALL.md).
 
-For a tutorial walkthrough of the example code, see EXAMPLE.md.
+For a tutorial walkthrough of the example code, see [EXAMPLE.md](doc/EXAMPLE.md).
 
 This project is intended to take a graph and build a smaller (upscaled)
 graph that is representative of the original in some way. We represent

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ smoothG [![Build Status](https://travis-ci.org/LLNL/smoothG.svg?branch=master)](
  +
  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ EHEADER -->
 
-![](smoothg_logo.png)
+!["smoothG logo](doc/smoothg_logo.png)
 
 Mixed graph-Laplacian upscaling and solvers.
 

--- a/doc/front.md
+++ b/doc/front.md
@@ -1,4 +1,4 @@
-smoothG [![Build Status](https://travis-ci.org/LLNL/smoothG.svg?branch=master)](https://travis-ci.org/LLNL/smoothG)
+smoothG               {#mainpage}
 =================
 
 <!-- BHEADER ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -20,9 +20,9 @@ smoothG [![Build Status](https://travis-ci.org/LLNL/smoothG.svg?branch=master)](
 
 Mixed graph-Laplacian upscaling and solvers.
 
-For installation instructions, see INSTALL.md.
+For installation instructions, see [INSTALL.md](@ref INSTALL)
 
-For a tutorial walkthrough of the example code, see EXAMPLE.md.
+For a tutorial walkthrough of the example code, see [EXAMPLE.md](@ref EXAMPLE)
 
 This project is intended to take a graph and build a smaller (upscaled)
 graph that is representative of the original in some way. We represent
@@ -41,8 +41,3 @@ This code has contributions from:
 - Stephan Gelever (gelever1@llnl.gov)
 - Chak Shing Lee (cslee@llnl.gov)
 - Colin Ponce (ponce11@llnl.gov)
-
-Copyright (c) 2018, Lawrence Livermore National Security, LLC.
-This work was performed under the auspices of the U.S. Department of Energy by
-Lawrence Livermore National Laboratory under Contract DE-AC52-07NA27344.
-LLNL-CODE-745247.


### PR DESCRIPTION
Separates README.md from doxygen front page.   This way the main github page looks better without all the doxygen markup.  It will probably be a bit more work to keep them in sync, but the trade off is worth it. 