### PR TITLE
extract the process of building 'entity_trueEntity' 

### DIFF
--- a/src/GraphCoarsen.hpp
+++ b/src/GraphCoarsen.hpp
@@ -266,9 +266,6 @@ private:
     /// edge coarse dof start array (for HypreParMatrix)
     mfem::Array<HYPRE_Int> edge_cd_start_;
 
-    /// edge coarse true dof start array (for HypreParMatrix)
-    mfem::Array<HYPRE_Int> edge_ctd_start_;
-
     /// vertex coarse dof start array (for HypreParMatrix)
     /// note that vertex coarse dof and coarse true dof is the same
     mfem::Array<HYPRE_Int> vertex_cd_start_;

--- a/src/GraphTopology.hpp
+++ b/src/GraphTopology.hpp
@@ -133,7 +133,6 @@ private:
     mfem::Array<HYPRE_Int> edge_start_;
     mfem::Array<HYPRE_Int> aggregate_start_;
     mfem::Array<HYPRE_Int> face_start_;
-    mfem::Array<HYPRE_Int> trueface_start_;
 }; // class GraphTopology
 
 } // namespace smoothg

--- a/src/HybridSolver.cpp
+++ b/src/HybridSolver.cpp
@@ -221,45 +221,8 @@ void HybridSolver::Init(const mfem::SparseMatrix& face_edgedof,
         unique_ptr<mfem::HypreParMatrix> multiplier_d_td_d(
             smoothg::RAP(*edgedof_d_td_d, *edgedof_multiplier_d) );
 
-        // Create a selection matrix to set dofs on true faces to be true dofs
-        hypre_ParCSRMatrix* multiplier_shared = *multiplier_d_td_d;
-        HYPRE_Int* multiplier_shared_i = multiplier_shared->offd->i;
-        HYPRE_Int* multiplier_shared_j = multiplier_shared->offd->j;
-        HYPRE_Int* multiplier_shared_map = multiplier_shared->col_map_offd;
-        HYPRE_Int maxmultiplier = multiplier_shared->last_row_index;
-
-        // Create a selection matrix to pick one of the processors sharing a true
-        // face to own the true face (we pick the processor with a smaller index)
-        int* select_i = new int[num_multiplier_dofs_ + 1];
-        int ntruemultipliers = 0;
-        for (int i = 0; i < num_multiplier_dofs_; i++)
-        {
-            select_i[i] = ntruemultipliers;
-            if (multiplier_shared_i[i + 1] == multiplier_shared_i[i])
-                ntruemultipliers++;
-            else if (multiplier_shared_map[ multiplier_shared_j[
-                                                multiplier_shared_i[i] ] ] > maxmultiplier)
-                ntruemultipliers++;
-        }
-        select_i[num_multiplier_dofs_] = ntruemultipliers;
-        int* select_j = new int[ntruemultipliers];
-        double* select_data = new double[ntruemultipliers];
-        std::iota(select_j, select_j + ntruemultipliers, 0);
-        std::fill_n(select_data, ntruemultipliers, 1.);
-        mfem::SparseMatrix select(select_i, select_j, select_data,
-                                  num_multiplier_dofs_, ntruemultipliers);
-
-        // Construct a (block diagonal) global select matrix from local
-        GenerateOffsets(comm_, ntruemultipliers, truemultiplier_start_);
-
-        mfem::HypreParMatrix select_d(
-            comm_, multiplier_start_.Last(), truemultiplier_start_.Last(),
-            multiplier_start_, truemultiplier_start_, &select);
-
-        // Construct face "dof to true dof" table
-        multiplier_d_td_.reset( ParMult(multiplier_d_td_d.get(), &select_d) );
-        multiplier_d_td_->CopyRowStarts();
-        multiplier_d_td_->CopyColStarts();
+        // Construct multiplier "dof to true dof" table
+        multiplier_d_td_ = BuildEntityToTrueEntity(*multiplier_d_td_d);
     }
 
     // Assemble the hybridized system

--- a/src/HybridSolver.hpp
+++ b/src/HybridSolver.hpp
@@ -214,7 +214,6 @@ private:
     bool ess_multiplier_bc_;
     mfem::Array<int> ess_multiplier_dofs_;
     mfem::Array<HYPRE_Int> multiplier_start_;
-    mfem::Array<HYPRE_Int> truemultiplier_start_;
 
     std::unique_ptr<mfem::HypreParMatrix> multiplier_d_td_;
 

--- a/src/MatrixUtilities.cpp
+++ b/src/MatrixUtilities.cpp
@@ -1000,4 +1000,50 @@ double InnerProduct(const mfem::Vector& u, const mfem::Vector& v)
     return out;
 }
 
+std::unique_ptr<mfem::HypreParMatrix> BuildEntityToTrueEntity(
+    const mfem::HypreParMatrix& entity_trueentity_entity)
+{
+    hypre_ParCSRMatrix* entity_shared = entity_trueentity_entity;
+    HYPRE_Int* entity_shared_i = entity_shared->offd->i;
+    HYPRE_Int* entity_shared_j = entity_shared->offd->j;
+    HYPRE_Int* entity_shared_map = entity_shared->col_map_offd;
+    HYPRE_Int max_entity = entity_shared->last_row_index;
+
+    // Diagonal part
+    int nentities = entity_trueentity_entity.Width();
+    int* select_i = new int[nentities + 1];
+    int ntrueentities = 0;
+    for (int i = 0; i < nentities; i++)
+    {
+        select_i[i] = ntrueentities;
+        int j_offset = entity_shared_i[i];
+        if (entity_shared_i[i + 1] == j_offset)
+            ntrueentities++;
+        else if (entity_shared_map[entity_shared_j[j_offset]] > max_entity)
+            ntrueentities++;
+    }
+    select_i[nentities] = ntrueentities;
+    int* select_j = new int[ntrueentities];
+    double* select_data = new double[ntrueentities];
+    std::iota(select_j, select_j + ntrueentities, 0);
+    std::fill_n(select_data, ntrueentities, 1.);
+    mfem::SparseMatrix select_diag(select_i, select_j, select_data,
+                                   nentities, ntrueentities);
+
+    // Construct a "block diagonal" global select matrix from local
+    auto comm = entity_trueentity_entity.GetComm();
+    mfem::Array<int> trueentity_starts;
+    GenerateOffsets(comm, ntrueentities, trueentity_starts);
+
+    mfem::HypreParMatrix select(
+        comm, entity_shared->global_num_rows, trueentity_starts.Last(),
+        entity_shared->row_starts, trueentity_starts, &select_diag);
+
+    auto out = mfem::ParMult(&entity_trueentity_entity, &select);
+    out->CopyRowStarts();
+    out->CopyColStarts();
+
+    return unique_ptr<mfem::HypreParMatrix>(out);
+}
+
 } // namespace smoothg

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -373,6 +373,17 @@ double InnerProduct(const mfem::Vector& weight, const mfem::Vector& u,
 */
 double InnerProduct(const mfem::Vector& u, const mfem::Vector& v);
 
+/**
+   @brief Construct entity to true entity table from entity_trueentity_entity
+
+   Pick one of the processors sharing a true entity to own the true entity
+   (pick the processor with a smaller id)
+
+   @param entity_trueentity_entity = entity_trueentity * trueentity_entity
+*/
+std::unique_ptr<mfem::HypreParMatrix> BuildEntityToTrueEntity(
+    const mfem::HypreParMatrix& entity_trueentity_entity);
+
 } // namespace smoothg
 
 #endif /* __MATRIXUTILITIES_HPP__ */

--- a/src/MinresBlockSolver.cpp
+++ b/src/MinresBlockSolver.cpp
@@ -58,10 +58,9 @@ void MinresBlockSolver::Init(mfem::HypreParMatrix* M, mfem::HypreParMatrix* D,
     operator_.SetBlock(1, 0, D);
 
     std::unique_ptr<mfem::HypreParMatrix> MinvDt(D->Transpose());
-    std::unique_ptr<mfem::HypreParVector> Md = make_unique<mfem::HypreParVector>(
-                                                   comm_, M->GetGlobalNumRows(), M->GetRowStarts());
-    M->GetDiag(*Md);
-    MinvDt->InvScaleRows(*Md);
+    mfem::Vector Md;
+    M->GetDiag(Md);
+    MinvDt->InvScaleRows(Md);
     schur_block_.reset(ParMult(D, MinvDt.get()));
 
     // D retains ownership of rows, but MinvDt will be deleted, so we need to
@@ -147,8 +146,8 @@ MinresBlockSolver::MinresBlockSolver(MPI_Comm comm, const MixedMatrix& mgL)
     mfem::HypreParMatrix M(comm, edge_d_td.M(),
                            edge_d_td.GetRowStarts(), &M_);
 
-    std::unique_ptr<mfem::HypreParMatrix> M_tmp(ParMult(&M,
-                                                        const_cast<mfem::HypreParMatrix*>(&edge_d_td)));
+    std::unique_ptr<mfem::HypreParMatrix> M_tmp(
+        ParMult(&M, const_cast<mfem::HypreParMatrix*>(&edge_d_td)));
     hM_.reset(ParMult(const_cast<mfem::HypreParMatrix*>(&edge_td_d), M_tmp.get()));
     hypre_ParCSRMatrixSetNumNonzeros(*hM_);
 


### PR DESCRIPTION
extract the process of building 'entity_trueEntity' from 'entity_trueEntity_entity' to reduce repeated code.

(the block of code in `GraphCoarsen.cpp` is not exactly the same, but the results should be the same as it is based on the same logic when choose true entities)