### PR TITLE
Fix/memory leak

### DIFF
--- a/examples/finitevolume.cpp
+++ b/examples/finitevolume.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
     picojson::object serialize;
 
     // 1. Initialize MPI
-    MPI_Init(&argc, &argv);
+    mpi_session session(argc, argv);
     MPI_Comm comm = MPI_COMM_WORLD;
     MPI_Comm_size(comm, &num_procs);
     MPI_Comm_rank(comm, &myid);

--- a/examples/spe10.hpp
+++ b/examples/spe10.hpp
@@ -247,6 +247,7 @@ SPE10Problem::SPE10Problem(const char* permFile, int nDimensions,
 
 SPE10Problem::~SPE10Problem()
 {
+    smoothg::InversePermeabilityFunction::ClearMemory();
     delete source_coeff_;
     delete kinv_;
     delete pmesh_;

--- a/examples/timestep.cpp
+++ b/examples/timestep.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
     picojson::object serialize;
 
     // 1. Initialize MPI
-    MPI_Init(&argc, &argv);
+    mpi_session session(argc, argv);
     MPI_Comm comm = MPI_COMM_WORLD;
     MPI_Comm_size(comm, &num_procs);
     MPI_Comm_rank(comm, &myid);
@@ -356,10 +356,6 @@ int main(int argc, char* argv[])
             std::cout << "Total Time: " << chrono.RealTime() << "\n";
         }
     }
-
-    InversePermeabilityFunction::ClearMemory();
-
-    MPI_Finalize();
 
     return 0;
 }

--- a/src/LocalEigenSolver.cpp
+++ b/src/LocalEigenSolver.cpp
@@ -358,6 +358,28 @@ public:
 
 }; // class ARSymStdEig_.
 
+/*! @brief Derived class to avoid uninitialized value Valgrind error */
+template<class ARFLOAT, class ARFOP, class ARFB>
+class ARSymGenEig_: public virtual ARSymGenEig<ARFLOAT, ARFOP, ARFB>
+{
+public:
+    using ARSymGenEig<ARFLOAT, ARFOP, ARFB>::HowMny;
+
+    ARSymGenEig_(int np, int nevp, ARFOP* objOPp,
+                void (ARFOP::* MultOPxp)(ARFLOAT[], ARFLOAT[]), ARFB* objBp,
+                void (ARFB::* MultBxp)(ARFLOAT[], ARFLOAT[]),
+                const std::string& whichp = "LM", int ncvp = 0, ARFLOAT tolp = 0.0,
+                int maxitp = 0, ARFLOAT* residp = NULL, bool ishiftp = true)
+        : ARSymGenEig<ARFLOAT, ARFOP, ARFB>(np, nevp, objOPp, MultOPxp, objBp, MultBxp,
+                                            whichp, ncvp, tolp, maxitp, residp, ishiftp)
+    {
+        HowMny = 'A';
+    }
+
+    virtual ~ARSymGenEig_() { }
+
+}; // class ARSymGenEig_.
+
 // ncv is the number of Arnoldi vectors generated at each iteration of ARPACK
 int ComputeNCV(int size, int num_evects, int num_arnoldi_vectors)
 {
@@ -438,7 +460,7 @@ void LocalEigenSolver::Compute(
         // TODO: more efficient way to find eig_max of generalized eigen problem
         // Find the largest eigenvalue
         B_inv_A_adapter adapter_B_inv_A(A, B);
-        ARSymGenEig<double, B_inv_A_adapter, A_adapter>
+        ARSymGenEig_<double, B_inv_A_adapter, A_adapter>
         eigvalueprob(A.Height(), 1,
                      &adapter_B_inv_A, &B_inv_A_adapter::MultOP,
                      &adapter_B, &A_adapter::MultOP,

--- a/src/LocalEigenSolver.cpp
+++ b/src/LocalEigenSolver.cpp
@@ -366,10 +366,10 @@ public:
     using ARSymGenEig<ARFLOAT, ARFOP, ARFB>::HowMny;
 
     ARSymGenEig_(int np, int nevp, ARFOP* objOPp,
-                void (ARFOP::* MultOPxp)(ARFLOAT[], ARFLOAT[]), ARFB* objBp,
-                void (ARFB::* MultBxp)(ARFLOAT[], ARFLOAT[]),
-                const std::string& whichp = "LM", int ncvp = 0, ARFLOAT tolp = 0.0,
-                int maxitp = 0, ARFLOAT* residp = NULL, bool ishiftp = true)
+                 void (ARFOP::* MultOPxp)(ARFLOAT[], ARFLOAT[]), ARFB* objBp,
+                 void (ARFB::* MultBxp)(ARFLOAT[], ARFLOAT[]),
+                 const std::string& whichp = "LM", int ncvp = 0, ARFLOAT tolp = 0.0,
+                 int maxitp = 0, ARFLOAT* residp = NULL, bool ishiftp = true)
         : ARSymGenEig<ARFLOAT, ARFOP, ARFB>(np, nevp, objOPp, MultOPxp, objBp, MultBxp,
                                             whichp, ncvp, tolp, maxitp, residp, ishiftp)
     {


### PR DESCRIPTION
Fix still reachable memory leak in `finitevolume.cpp` (the allocated memory in `InversePermeabilityFunction` is not deleted).

 There is also the `Conditional jump or move depends on uninitialised value(s)` error in the use of `arpackpp`. But I dont know how to fix that. It is not a leak?