### PR TITLE
Allow some unbalance in processor partitioning

### DIFF
--- a/examples/finitevolume.cpp
+++ b/examples/finitevolume.cpp
@@ -75,6 +75,9 @@ int main(int argc, char* argv[])
     args.AddOption(&metis_agglomeration, "-ma", "--metis-agglomeration",
                    "-nm", "--no-metis-agglomeration",
                    "Use Metis as the partitioner (instead of geometric).");
+    double proc_part_ubal = 2.0;
+    args.AddOption(&proc_part_ubal, "-pub", "--part-unbalance",
+                   "Processor partition unbalance factor.");
     int spe10_scale = 5;
     args.AddOption(&spe10_scale, "-sc", "--spe10-scale",
                    "Scale of problem, 1=small, 5=full SPE10.");
@@ -132,7 +135,7 @@ int main(int argc, char* argv[])
 
     // Setting up finite volume discretization problem
     SPE10Problem spe10problem(permFile, nDimensions, spe10_scale, slice,
-                              metis_agglomeration, coarseningFactor);
+                              metis_agglomeration, proc_part_ubal, coarseningFactor);
 
     mfem::ParMesh* pmesh = spe10problem.GetParMesh();
 

--- a/examples/spe10.hpp
+++ b/examples/spe10.hpp
@@ -112,7 +112,7 @@ class SPE10Problem
 {
 public:
     SPE10Problem(const char* permFile, int nDimensions, int spe10_scale,
-                 int slice, bool metis_partition,
+                 int slice, bool metis_partition, double proc_part_ubal,
                  const mfem::Array<int>& coarsening_factor);
     ~SPE10Problem();
     mfem::ParMesh* GetParMesh()
@@ -144,7 +144,7 @@ private:
 };
 
 SPE10Problem::SPE10Problem(const char* permFile, int nDimensions,
-                           int spe10_scale, int slice,  bool metis_partition,
+                           int spe10_scale, int slice,  bool metis_partition, double proc_part_ubal,
                            const mfem::Array<int>& coarsening_factor)
 {
     int num_procs, myid;
@@ -209,7 +209,9 @@ SPE10Problem::SPE10Problem(const char* permFile, int nDimensions,
         auto elem_elem = TableToSparse(mesh->ElementToElementTable());
 
         mfem::Array<int> partition;
-        Partition(elem_elem, partition, num_procs);
+        MetisGraphPartitioner partitioner;
+        partitioner.setUnbalanceTol(proc_part_ubal);
+        partitioner.doPartition(elem_elem, num_procs, partition);
 
         pmesh_  = new mfem::ParMesh(comm, *mesh, partition);
 

--- a/examples/spe10.hpp
+++ b/examples/spe10.hpp
@@ -24,6 +24,9 @@
 
 using std::unique_ptr;
 
+namespace smoothg
+{
+
 /**
    @brief A forcing function that is supposed to very roughly represent some wells
    that are resolved on the *coarse* level.
@@ -203,7 +206,14 @@ SPE10Problem::SPE10Problem(const char* permFile, int nDimensions,
 
     if (metis_partition)
     {
-        pmesh_  = new mfem::ParMesh(comm, *mesh);
+        auto elem_elem = TableToSparse(mesh->ElementToElementTable());
+
+        mfem::Array<int> partition;
+        Partition(elem_elem, partition, num_procs);
+
+        pmesh_  = new mfem::ParMesh(comm, *mesh, partition);
+
+        assert(partition.Max() + 1 == num_procs);
     }
     else
     {
@@ -252,4 +262,6 @@ SPE10Problem::~SPE10Problem()
     delete kinv_;
     delete pmesh_;
 }
+
+} // namespace smoothg
 

--- a/examples/timestep.cpp
+++ b/examples/timestep.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
     double initial_val = 1.0;
     args.AddOption(&initial_val, "-iv", "--initial-value",
                    "Initial pressure difference.");
-    int vis_step = 100;
+    int vis_step = 0;
     args.AddOption(&vis_step, "-vs", "--vis_step",
                    "Step size for visualization.");
     int k = 1;

--- a/examples/timestep.cpp
+++ b/examples/timestep.cpp
@@ -82,6 +82,9 @@ int main(int argc, char* argv[])
     args.AddOption(&metis_agglomeration, "-ma", "--metis-agglomeration",
                    "-nm", "--no-metis-agglomeration",
                    "Use Metis as the partitioner (instead of geometric).");
+    double proc_part_ubal = 2.0;
+    args.AddOption(&proc_part_ubal, "-pub", "--part-unbalance",
+                   "Processor partition unbalance factor.");
     int spe10_scale = 5;
     args.AddOption(&spe10_scale, "-sc", "--spe10-scale",
                    "Scale of problem, 1=small, 5=full SPE10.");
@@ -165,7 +168,7 @@ int main(int argc, char* argv[])
 
     // Setting up finite volume discretization problem
     SPE10Problem spe10problem(permFile, nDimensions, spe10_scale, slice,
-                              metis_agglomeration, coarseningFactor);
+                              metis_agglomeration, proc_part_ubal, coarseningFactor);
     mfem::ParMesh* pmesh = spe10problem.GetParMesh();
 
     for (int i = 0; i < num_refine; ++i)


### PR DESCRIPTION
Partitioning the mesh across processors outside MFEM lets us set an unbalance tolerance.
In my testing this produces better results as METIS has more play to optimize the number of edge cuts.

### On a once refined SPE10 mesh : 
Original, no unbalanced tolerance
```
time mpirun -np 8 ./finitevolume --dim 3 -m 4 -t .10 -ma -hb
Options used:
   --max-evects 4
   --spect-tol 0.1
   --metis-agglomeration
   --spe10-scale 5
   --hybridization
// ...  irrelevant args removed to save space
3438088 fine edges, 3401664 fine faces, 1121864 fine elements

Processors: 8
---------------------
Fine Matrix
---------------------
Size            36052000
NonZeros:       134788000

Coarse Matrix
---------------------
Size            605484
NonZeros:       600930

Op Comp:        1.17

Upscale Setup Time:      194.7

Coarse Solve Time:       287.991
Coarse Solve Iterations: 2688

Fine Solve Time:         57.52
Fine Solve Iterations:   22
{
  "finest-div-error": 0.32307985763419617,
  "finest-p-error": 0.43528911715481983,
  "finest-u-error": 0.64475987000378587,
  "operator-complexity": 1.1725354944728636
}

real    9m41.518s
user    74m19.232s
sys     1m35.285s
```
vs Allowing some unbalance
```
time mpirun -np 8 ./finitevolume --dim 3 -m 4 -t .10 -ma -hb
// ...  same as above 
Coarse Matrix
---------------------
Size            604716
NonZeros:       600234

Op Comp:        1.17

Upscale Setup Time:      194.979

Coarse Solve Time:       213.376
Coarse Solve Iterations: 1981

Fine Solve Time:         54.3113
Fine Solve Iterations:   22
{
  "finest-div-error": 0.34983192389957152,
  "finest-p-error": 0.40914296492415175,
  "finest-u-error": 0.62515876852662322,
  "operator-complexity": 1.1718853642241089
}

real    8m29.240s
user    64m58.563s
sys     1m49.336s
```
 In this case, it still does not beat the fine solver, but an non-insignificant improvement vs the previous partitioning.

I'm not sure if there are downsides to allowing imbalance.  The setup time seems to stay about the same.  A concern might be that it may produce empty partitions for some edge cases (where `num_procs` is close to `num_elements`). 

This may not be better in every scenario so perhaps this could be user set?