### PR TITLE
Fix zero size mult, add all tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,12 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          # sources:
-            # - ubuntu-toolchain-r-test
           packages:
-            # GCC 4.9
-            # - g++-4.9
-            # MPICH
-            #- mpich
-            #- libmpich-dev
-            # Other
             - liblapack-dev
             - libblas-dev
             - doxygen
             - valgrind
             - gfortran
-            # OpenMPI
-            #- gfortran
-            #- openmpi-bin
-            #- libopenmpi-dev
       env: DEBUG=YES
            MPI=YES
       cache:
@@ -167,15 +155,13 @@ script:
      CPPFLAGS="";
      SKIP_TEST_DIRS="";
 
-
    # Configure the library
    - mkdir build;
    - cd build;
-   - CC=gcc CXX=g++ cmake -DMFEM_DIR="/home/travis/build/LLNL/mfem-install" -DHYPRE_DIR="/home/travis/build/LLNL/hypre-install" -DSuiteSparse_DIR="/home/travis/build/LLNL/SuiteSparse-install" -DMETIS_DIR="/home/travis/build/LLNL/metis-install" -DUSE_ARPACK=OFF -DCMAKE_BUILD_TYPE=DEBUG -DSPE10_PERM="/home/travis/build/LLNL/spe10-install/spe_perm.dat" ..;
+   - CC=mpicc CXX=mpic++ cmake -DMFEM_DIR="/home/travis/build/LLNL/mfem-install" -DHYPRE_DIR="/home/travis/build/LLNL/hypre-install" -DSuiteSparse_DIR="/home/travis/build/LLNL/SuiteSparse-install" -DMETIS_DIR="/home/travis/build/LLNL/metis-install" -DUSE_ARPACK=OFF -DCMAKE_BUILD_TYPE=Debug -DSPE10_PERM="/home/travis/build/LLNL/spe10-install/spe_perm.dat" -DSMOOTHG_TEST_PROCS=2 -DSMOOTHG_TEST_TOL="1e-2" ..;
 
    # Build the library
    - make -j3
 
    # Run tests
-   - cd testcode;
    - env CTEST_OUTPUT_ON_FAILURE=1 make test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,14 @@ script:
    # Configure the library
    - mkdir build;
    - cd build;
-   - CC=mpicc CXX=mpic++ cmake -DMFEM_DIR="/home/travis/build/LLNL/mfem-install" -DHYPRE_DIR="/home/travis/build/LLNL/hypre-install" -DSuiteSparse_DIR="/home/travis/build/LLNL/SuiteSparse-install" -DMETIS_DIR="/home/travis/build/LLNL/metis-install" -DUSE_ARPACK=OFF -DCMAKE_BUILD_TYPE=Debug -DSPE10_PERM="/home/travis/build/LLNL/spe10-install/spe_perm.dat" -DSMOOTHG_TEST_PROCS=2 -DSMOOTHG_TEST_TOL="1e-2" ..;
+   - |
+       CC=mpicc CXX=mpic++ cmake -DMFEM_DIR="/home/travis/build/LLNL/mfem-install" \
+       -DHYPRE_DIR="/home/travis/build/LLNL/hypre-install" \
+       -DSuiteSparse_DIR="/home/travis/build/LLNL/SuiteSparse-install" \
+       -DMETIS_DIR="/home/travis/build/LLNL/metis-install" \
+       -DUSE_ARPACK=OFF -DCMAKE_BUILD_TYPE=Debug \
+       -DSPE10_PERM="/home/travis/build/LLNL/spe10-install/spe_perm.dat" \
+       -DSMOOTHG_TEST_PROCS=2 -DSMOOTHG_TEST_TOL="1e-2" ..;
 
    # Build the library
    - make -j3

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,6 +38,13 @@ add_executable(mlmc mlmc.cpp)
 target_link_libraries(mlmc smoothg ${TPL_LIBRARIES})
 
 # add tests
+if (NOT DEFINED SMOOTHG_TEST_PROCS)
+    set(SMOOTHG_TEST_PROCS 4)
+endif()
+if (NOT DEFINED SMOOTHG_TEST_TOL)
+    set(SMOOTHG_TEST_TOL 1e-4)
+endif()
+
 configure_file(
   "${PROJECT_SOURCE_DIR}/examples/stest.py"
   "${PROJECT_BINARY_DIR}/examples/stest.py" @ONLY)

--- a/examples/graphupscale.cpp
+++ b/examples/graphupscale.cpp
@@ -165,9 +165,11 @@ int main(int argc, char* argv[])
 
 #if SMOOTHG_USE_SAAMGE
         SAAMGeParam saamge_param;
+        const bool coarse_coefficient = false;
         const auto hbsa_upscale = GraphUpscale(comm, vertex_edge, coarse_factor,
                                                spect_tol, max_evects, dual_target,
                                                scaled_dual, energy_dual, use_hybridization,
+                                               coarse_coefficient,
                                                mfem::Vector(), &saamge_param);
 
         const auto hbsa_sol = hbsa_upscale.Solve(rhs_u_fine);

--- a/examples/stest.py
+++ b/examples/stest.py
@@ -34,6 +34,10 @@ spe10_perm_file = "@SPE10_PERM@"
 graph_data = "@smoothG_GRAPHDATA@"
 memorycheck_command = "@MEMORYCHECK_COMMAND@"
 
+# Test paramaters
+num_procs = "@SMOOTHG_TEST_PROCS@"
+test_tol = float("@SMOOTHG_TEST_TOL@")
+
 def run_test(command, expected={}, verbose=False):
     """ Executes test
 
@@ -65,7 +69,7 @@ def run_test(command, expected={}, verbose=False):
     for key, expected_val in expected.items():
         test_val = output[key]
 
-        if abs(float(expected_val) - float(test_val)) > 1.e-4:
+        if abs(float(expected_val) - float(test_val)) > test_tol:
             return False
 
     return True
@@ -227,7 +231,7 @@ def make_tests():
           "operator-complexity": 1.016509834901651}]
 
     tests["parsamplegraph1-coeff"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "1",
           "--coarse-coefficient"],
@@ -330,7 +334,7 @@ def make_tests():
           "--perm", spe10_perm_file]]
 
     tests["pareigenvector1"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "0",
           "--max-evects", "1",
@@ -341,7 +345,7 @@ def make_tests():
           "operator-complexity": 1.0221724964280585}]
 
     tests["pareigenvector4"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "0",
           "--max-evects", "4",
@@ -352,7 +356,7 @@ def make_tests():
           "operator-complexity": 1.3017591339648173}]
 
     tests["parfv-hybridization"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "0",
           "--max-evects", "4",
@@ -364,7 +368,7 @@ def make_tests():
           "operator-complexity": 1.1362437864707153}]
 
     tests["parslice19"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "19",
           "--max-evects", "1",
@@ -375,7 +379,7 @@ def make_tests():
           "operator-complexity": 1.0221724964280585}]
 
     tests["pardual-trace"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "0",
           "--max-evects", "4",
@@ -387,7 +391,7 @@ def make_tests():
           "operator-complexity": 1.3017591339648173}]
 
     tests["parscaled-dual-trace"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "0",
           "--max-evects", "4",
@@ -400,7 +404,7 @@ def make_tests():
           "operator-complexity": 1.3017591339648173}]
 
     tests["parenergy-dual-trace"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "0",
           "--max-evects", "4",
@@ -413,7 +417,7 @@ def make_tests():
           "operator-complexity": 1.3017591339648173}]
 
     tests["parscaled-energy-dual-trace"] = \
-        [["mpirun", "-n", "4", "./finitevolume",
+        [["mpirun", "-n", num_procs, "./finitevolume",
           "--spect-tol", "1.0",
           "--slice", "0",
           "--max-evects", "4",
@@ -427,7 +431,7 @@ def make_tests():
           "operator-complexity": 1.3017591339648173}]
 
     tests["parsamplegraph1"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "1"],
          {"finest-div-error": 0.37918423727222522,
@@ -436,7 +440,7 @@ def make_tests():
           "operator-complexity": 1.016509834901651}]
 
     tests["pargraph-metis"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "1",
           "--metis-agglomeration"],
@@ -446,7 +450,7 @@ def make_tests():
           "operator-complexity": 1.016509834901651}]
 
     tests["pargraph-metis-mac"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "1",
           "--metis-agglomeration"],
@@ -456,7 +460,7 @@ def make_tests():
           "operator-complexity": 1.016509834901651}]
 
     tests["parsamplegraph4"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "4"],
          {"finest-div-error": 0.12043046187567592,
@@ -465,7 +469,7 @@ def make_tests():
           "operator-complexity": 1.2578874211257887}]
 
     tests["pargraph-hybridization"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "4",
           "--hybridization"],
@@ -475,7 +479,7 @@ def make_tests():
           "operator-complexity": 1.013984620448976}]
 
     tests["pargraph-usegenerator"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "4",
           "--generate-graph"],
@@ -485,7 +489,7 @@ def make_tests():
           "operator-complexity": 1.2578874211257887}]
 
     tests["pargraph-usegenerator-mac"] = \
-        [["mpirun", "-n", "4", "./generalgraph",
+        [["mpirun", "-n", num_procs, "./generalgraph",
           "--spect-tol", "1.0",
           "--max-evects", "4",
           "--generate-graph"],
@@ -495,14 +499,14 @@ def make_tests():
           "operator-complexity": 1.2578874211257887}]
 
     tests["parpoweriter"] = \
-        [["mpirun", "-n", "4", "./poweriter"],
+        [["mpirun", "-n", num_procs, "./poweriter"],
          {"coarse-error": 0.20499789652195419,
           "coarse-eval": 0.17663653207421526,
           "fine-error": 2.9887390635842169e-05,
           "fine-eval": 0.17545528997977797}]
 
     tests["partimestep"] = \
-        [["mpirun", "-n", "4", "./timestep",
+        [["mpirun", "-n", num_procs, "./timestep",
           "--total-time", "100.0",
           "--perm", spe10_perm_file]]
 
@@ -517,7 +521,7 @@ def make_tests():
     if "tux" in platform.node():
         tests["veigenvector"] = \
             [[memorycheck_command, "--leak-check=full",
-              "mpirun", "-n", "4", "./finitevolume",
+              "mpirun", "-n", num_procs, "./finitevolume",
               "--max-evects", "1",
               "--spe10-scale", "1",
               "--perm", spe10_perm_file]]

--- a/src/GraphCoarsenBuilder.cpp
+++ b/src/GraphCoarsenBuilder.cpp
@@ -258,8 +258,10 @@ mfem::DenseMatrix CoefficientMBuilder::RTDP(const mfem::DenseMatrix& R,
                                             const mfem::DenseMatrix& P)
 {
     mfem::DenseMatrix out(R.Width(), P.Width());
-    if (R.Width() == 0 || P.Width() == 0)
+    // MFEM w/ lapack breaks when these are 0
+    if (!R.Width() || !R.Height() || !P.Height() || !P.Width())
     {
+        out = 0.0;
         return out;
     }
     mfem::DenseMatrix Rt;


### PR DESCRIPTION
When checking out #16, I noticed there was a failing test `isolate-coarsen`.  ~~This is actually broken for me on master too.~~  Only broken w/ #16, not master.

This PR allows the test suite to have a variable number of processors and tolerance. Travis CI has 2 cores. When overcommitting w/ 4 cores the tests takes forever to complete.  Setting it to 2 cores lets us run all tests and it will complete in a reasonable time.  But the tolerance is lower to account for the different number of cores.  