### PR TITLE
Improve/elem coarse m

### DIFF
--- a/src/FiniteVolumeMLMC.cpp
+++ b/src/FiniteVolumeMLMC.cpp
@@ -98,8 +98,7 @@ FiniteVolumeMLMC::FiniteVolumeMLMC(MPI_Comm comm,
     // Hypre may modify the original vertex_edge, which we seek to avoid
     mfem::SparseMatrix ve_copy(vertex_edge);
 
-    auto fine_mbuilder = make_unique<FineMBuilder>(local_weight, vertex_edge);
-    mixed_laplacians_.emplace_back(vertex_edge, std::move(fine_mbuilder), edge_d_td_);
+    mixed_laplacians_.emplace_back(vertex_edge, local_weight, edge_d_td_);
 
     auto graph_topology = make_unique<GraphTopology>(ve_copy, edge_d_td_, partitioning,
                                                      &edge_boundary_att_);

--- a/src/FiniteVolumeMLMC.hpp
+++ b/src/FiniteVolumeMLMC.hpp
@@ -102,8 +102,7 @@ public:
 
     void MakeFineSolver();
 
-    /// coeff should have the size of the number of *edges* in the
-    /// fine graph (not exactly analagous to RescaleCoarseCoefficient)
+    /// coeff should have the size of the number of *vertices* in the fine graph
     void RescaleFineCoefficient(const mfem::Vector& coeff);
 
     /// coeff should have the size of the number of *aggregates*

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -491,7 +491,7 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
 
     mfem::SparseMatrix face_Agg(smoothg::Transpose(Agg_face));
 
-    auto edge_vert = smoothg::Transpose(D_proc_); // TODO: use vertex_edge
+    auto edge_vert = smoothg::Transpose(D_proc_);
     auto vert_Agg = smoothg::Transpose(Agg_vertex);
 
     mfem::Vector Mloc_v;

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -45,7 +45,7 @@ GraphCoarsen::GraphCoarsen(const MixedMatrix& mgL, const GraphTopology& graph_to
     W_proc_(mgL.GetW()),
     fine_mbuilder_(dynamic_cast<const FineMBuilder*>(&(mgL.GetMBuilder()))),
     graph_topology_(graph_topology),
-    colMapper_(M_proc_.Size())
+    colMapper_(D_proc_.Width())
 {
     assert(fine_mbuilder_);
     colMapper_ = -1;

--- a/src/GraphCoarsen.hpp
+++ b/src/GraphCoarsen.hpp
@@ -244,8 +244,8 @@ private:
     /**
        @brief Build fine-level aggregate sub-M corresponding to dofs on a face
     */
-    void BuildAggregateFaceM(const mfem::Array<int>& edge_dofs,
-                             const mfem::Array<int>& partition,
+    void BuildAggregateFaceM(const mfem::Array<int>& edge_dofs_on_face,
+                             const mfem::SparseMatrix& vert_Agg,
                              const mfem::SparseMatrix& edge_vert,
                              const int agg,
                              mfem::Vector& Mloc);

--- a/src/GraphCoarsen.hpp
+++ b/src/GraphCoarsen.hpp
@@ -61,31 +61,10 @@ public:
 
        This doesn't do much, just sets up the object to be coarsened.
 
-       @param M_proc edge-weighting matrix on fine level
-       @param D_proc directed vertex_edge (divergence) matrix
-       @param graph_topology describes vertex partitioning, agglomeration, etc.
-    */
-    GraphCoarsen(const mfem::SparseMatrix& M_proc,
-                 const mfem::SparseMatrix& D_proc,
-                 const GraphTopology& graph_topology);
-
-    GraphCoarsen(const mfem::SparseMatrix& M_proc,
-                 const mfem::SparseMatrix& D_proc,
-                 const mfem::SparseMatrix* W_proc,
-                 const GraphTopology& graph_topology);
-
-    /**
-       @brief Constructor based on the fine graph and a vertex partitioning.
-
-       This doesn't do much, just sets up the object to be coarsened.
-
        @param mgL describes fine graph
        @param graph_topology describes vertex partitioning, agglomeration, etc.
     */
-    GraphCoarsen(const MixedMatrix& mgL,
-                 const GraphTopology& graph_topology)
-        : GraphCoarsen( mgL.GetM(), mgL.GetD(), mgL.GetW(), graph_topology)
-    { }
+    GraphCoarsen(const MixedMatrix& mgL, const GraphTopology& graph_topology);
 
     /**
        @brief Given edge_trace and vertex_targets functions, construct the
@@ -258,13 +237,23 @@ private:
         std::vector<mfem::DenseMatrix>& vertex_target,
         mfem::SparseMatrix& face_cdof,
         mfem::SparseMatrix& Pedges,
-        CoarseMBuilder& coarse_m_builder);
+        CoarseMBuilder& coarse_mbuilder);
 
     void BuildW(const mfem::SparseMatrix& Pvertices);
+
+    /**
+       @brief Build fine-level aggregate sub-M corresponding to dofs on a face
+    */
+    void BuildAggregateFaceM(const mfem::Array<int>& edge_dofs,
+                             const mfem::Array<int>& partition,
+                             const mfem::SparseMatrix& edge_vert,
+                             const int agg,
+                             mfem::Vector& Mloc);
 
     const mfem::SparseMatrix& M_proc_;
     const mfem::SparseMatrix& D_proc_;
     const mfem::SparseMatrix* W_proc_;
+    const FineMBuilder* fine_mbuilder_;
     const GraphTopology& graph_topology_;
 
     /// Aggregate-to-coarse vertex dofs relation table

--- a/src/GraphCoarsenBuilder.cpp
+++ b/src/GraphCoarsenBuilder.cpp
@@ -22,9 +22,9 @@ namespace smoothg
 
 std::unique_ptr<mfem::SparseMatrix> MBuilder::BuildAssembledM() const
 {
-    mfem::Vector agg_weights(num_aggs_);
-    agg_weights = 1.0;
-    return BuildAssembledM(agg_weights);
+    mfem::Vector agg_weights_inverse(num_aggs_);
+    agg_weights_inverse = 1.0;
+    return BuildAssembledM(agg_weights_inverse);
 }
 
 void ElementMBuilder::Setup(

--- a/src/GraphCoarsenBuilder.hpp
+++ b/src/GraphCoarsenBuilder.hpp
@@ -47,9 +47,6 @@ public:
     /**
        @brief Assemble the rescaled M for the local processor
 
-       Build the assembled M with "element" contribution inversely scaled
-       by agg_weights_inverse.
-
        The point of this class is to be able to build the mass matrix M
        with different weights, without recoarsening the whole thing.
 
@@ -57,6 +54,8 @@ public:
        that is, agg_weights_inverse in the input is like the coefficient in
        a finite volume problem, agg_weights is the weights on the mass matrix
        in the mixed form, which is the reciprocal of that.
+
+       @note In the fine level, an agg is just a vertex.
     */
     virtual std::unique_ptr<mfem::SparseMatrix> BuildAssembledM(
         const mfem::Vector& agg_weights_inverse) const = 0;

--- a/src/MixedMatrix.cpp
+++ b/src/MixedMatrix.cpp
@@ -139,8 +139,7 @@ void MixedMatrix::ScaleM(const mfem::Vector& weight)
 void MixedMatrix::UpdateM(const mfem::Vector& agg_weights_inverse)
 {
     assert(mbuilder_);
-    mbuilder_->SetCoefficient(agg_weights_inverse);
-    M_ = mbuilder_->BuildAssembledM();
+    M_ = mbuilder_->BuildAssembledM(agg_weights_inverse);
 }
 
 /// @todo better documentation of the 1/-1 issue, make it optional?

--- a/src/MixedMatrix.cpp
+++ b/src/MixedMatrix.cpp
@@ -90,10 +90,11 @@ MixedMatrix::MixedMatrix(const mfem::SparseMatrix& vertex_edge,
 }
 
 MixedMatrix::MixedMatrix(const mfem::SparseMatrix& vertex_edge,
-                         std::unique_ptr<MBuilder> mbuilder,
+                         const std::vector<mfem::Vector>& local_weight,
                          const mfem::HypreParMatrix& edge_d_td)
-    : edge_d_td_(&edge_d_td), edge_td_d_(edge_d_td.Transpose()), mbuilder_(std::move(mbuilder))
+    : edge_d_td_(&edge_d_td), edge_td_d_(edge_d_td.Transpose())
 {
+    mbuilder_ = make_unique<FineMBuilder>(local_weight, vertex_edge);
     M_ = mbuilder_->BuildAssembledM();
     D_ = ConstructD(vertex_edge, edge_d_td);
     GenerateRowStarts();

--- a/src/MixedMatrix.hpp
+++ b/src/MixedMatrix.hpp
@@ -67,7 +67,7 @@ public:
                 DistributeWeight dist_weight = DistributeWeight::True);
 
     MixedMatrix(const mfem::SparseMatrix& vertex_edge,
-                std::unique_ptr<MBuilder> mbuilder,
+                const std::vector<mfem::Vector>& local_weight,
                 const mfem::HypreParMatrix& edge_d_td);
 
     MixedMatrix(std::unique_ptr<MBuilder> mbuilder,

--- a/testcode/lineargraph.cpp
+++ b/testcode/lineargraph.cpp
@@ -266,9 +266,14 @@ int main(int argc, char* argv[])
     mfem::SparseMatrix Pu;
     mfem::SparseMatrix Pp;
     mfem::SparseMatrix face_dof; // not used in this example
-    std::vector<mfem::DenseMatrix> CM_el_;
 
-    GraphCoarsen graph_coarsen(graph.GetM(), graph.GetD(), graph_topology);
+    mfem::Vector weight(graph.GetM().Size());
+    for (int i = 0; i < weight.Size(); i++)
+    {
+        weight(i) = graph.GetM()(i, i);
+    }
+    MixedMatrix mgL(graph.GetD(), weight, *partition.edge_d_td);
+    GraphCoarsen graph_coarsen(mgL, graph_topology);
     ElementMBuilder builder;
     graph_coarsen.BuildInterpolation(local_edge_traces, local_spectral_vertex_targets,
                                      Pp, Pu, face_dof, builder);

--- a/testcode/lineargraph.cpp
+++ b/testcode/lineargraph.cpp
@@ -270,7 +270,7 @@ int main(int argc, char* argv[])
     mfem::Vector weight(graph.GetM().Size());
     for (int i = 0; i < weight.Size(); i++)
     {
-        weight(i) = graph.GetM()(i, i);
+        weight(i) = 1.0 / graph.GetM()(i, i);
     }
     MixedMatrix mgL(graph.GetD(), weight, *partition.edge_d_td);
     GraphCoarsen graph_coarsen(mgL, graph_topology);

--- a/testcode/rescaling.cpp
+++ b/testcode/rescaling.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
 
     //Create simple element and aggregate scaling
     mfem::Vector elem_scale = SimpleAscendingScaling(pmesh->GetNE());
-    mfem::Vector agg_scale = SimpleAscendingScaling(partitioning.Max()+1);
+    mfem::Vector agg_scale = SimpleAscendingScaling(partitioning.Max() + 1);
 
     // Create a fine level MixedMatrix corresponding to piecewise constant coefficient
     auto fine_mgL = OriginalScaledFineMatrix(sigmafespace, vertex_edge, elem_scale);
@@ -177,8 +177,8 @@ int main(int argc, char* argv[])
     unique_ptr<mfem::SparseMatrix> coarse_M2(mfem::RAP(Psigma, fine_M2, Psigma));
 
     // Check relative differences measured in Frobenius norm
-    bool fine_rescale_fail = (RelativeDiff(comm, fine_M1, fine_M2) > 1e-16);
-    bool coarse_rescale_fail = (RelativeDiff(comm, coarse_M1, *coarse_M2) > 1e-16);
+    bool fine_rescale_fail = (RelativeDiff(comm, fine_M1, fine_M2) > 1e-14);
+    bool coarse_rescale_fail = (RelativeDiff(comm, coarse_M1, *coarse_M2) > 1e-14);
     if (myid == 0 && fine_rescale_fail)
     {
         std::cerr << "Fine level rescaling is NOT working as expected! \n";

--- a/testcode/rescaling.cpp
+++ b/testcode/rescaling.cpp
@@ -27,14 +27,35 @@
 using namespace smoothg;
 using std::unique_ptr;
 
-MixedMatrix UnscaledFineMixedMatrix(mfem::ParFiniteElementSpace& sigmafespace,
-                                    const mfem::SparseMatrix& vertex_edge)
+const mfem::Vector SimpleAscendingScaling(const int size)
 {
-    mfem::BilinearForm a2(&sigmafespace);
-    a2.AddDomainIntegrator(new FiniteVolumeMassIntegrator());
+    mfem::Vector scale(size);
+    for (int i = 0; i < size; i++)
+    {
+        scale(i) = i + 1;
+    }
+    return scale;
+}
 
-    std::vector<mfem::Vector> local_weight;
-    local_weight.resize(sigmafespace.GetMesh()->GetNE());
+mfem::PWConstCoefficient InvElemScaleCoefficient(const mfem::Vector& elem_scale)
+{
+    mfem::Vector inverse_elem_scale(elem_scale.Size());
+    for (int elem = 0; elem < elem_scale.Size(); elem++)
+    {
+        inverse_elem_scale(elem) = 1.0 / elem_scale(elem);
+    }
+    return mfem::PWConstCoefficient(inverse_elem_scale);
+}
+
+MixedMatrix OriginalScaledFineMatrix(mfem::ParFiniteElementSpace& sigmafespace,
+                                     const mfem::SparseMatrix& vertex_edge,
+                                     const mfem::Vector& elem_scale)
+{
+    auto inv_scale_coef = InvElemScaleCoefficient(elem_scale);
+    mfem::BilinearForm a2(&sigmafespace);
+    a2.AddDomainIntegrator(new FiniteVolumeMassIntegrator(inv_scale_coef));
+
+    std::vector<mfem::Vector> local_weight(sigmafespace.GetMesh()->GetNE());
     mfem::DenseMatrix M_el_i;
     for (unsigned int i = 0; i < local_weight.size(); i++)
     {
@@ -46,28 +67,22 @@ MixedMatrix UnscaledFineMixedMatrix(mfem::ParFiniteElementSpace& sigmafespace,
             local_weight_i[j] = 1.0 / M_el_i(j, j);
         }
     }
-
     auto edge_trueedge = sigmafespace.Dof_TrueDof_Matrix();
-    auto mbuilder =  make_unique<FineMBuilder>(local_weight, vertex_edge);
-    return MixedMatrix(vertex_edge, std::move(mbuilder), *edge_trueedge);
+    return MixedMatrix(vertex_edge, local_weight, *edge_trueedge);
 }
 
-mfem::SparseMatrix ScaledFineM(mfem::FiniteElementSpace& sigmafespace,
-                               const mfem::Vector& elem_scale)
+mfem::SparseMatrix RescaledFineM(mfem::FiniteElementSpace& sigmafespace,
+                                 const mfem::Vector& original_elem_scale,
+                                 const mfem::Vector& additional_elem_scale)
 {
-    mfem::Mesh* mesh = sigmafespace.GetMesh();
-    const int nDimensions = mesh->SpaceDimension();
-    mfem::L2_FECollection ufec(0, nDimensions);
-    mfem::FiniteElementSpace ufespace(mesh, &ufec);
-    mfem::GridFunction inverse_elem_scale(&ufespace);
-    for (int elem = 0; elem < elem_scale.Size(); elem++)
+    mfem::Vector new_elem_scale(original_elem_scale);
+    for (int i = 0; i < new_elem_scale.Size(); i++)
     {
-        inverse_elem_scale(elem) = 1.0 / elem_scale(elem);
+        new_elem_scale(i) *= additional_elem_scale(i);
     }
-    mfem::GridFunctionCoefficient inv_scale_coef(&inverse_elem_scale);
-
+    auto new_inv_scale_coef = InvElemScaleCoefficient(new_elem_scale);
     mfem::BilinearForm a1(&sigmafespace);
-    a1.AddDomainIntegrator(new FiniteVolumeMassIntegrator(inv_scale_coef));
+    a1.AddDomainIntegrator(new FiniteVolumeMassIntegrator(new_inv_scale_coef));
     a1.Assemble();
     a1.Finalize();
     return mfem::SparseMatrix(a1.SpMat());
@@ -92,10 +107,9 @@ unique_ptr<SpectralAMG_MGL_Coarsener> BuildCoarsener(mfem::SparseMatrix& v_e,
 double FrobeniusNorm(MPI_Comm comm, const mfem::SparseMatrix& mat)
 {
     double frob_norm_square, frob_norm_square_loc = 0.0;
-    double* mat_data = mat.GetData();
     for (int i = 0; i < mat.NumNonZeroElems(); i++)
     {
-        frob_norm_square_loc += (mat_data[i] * mat_data[i]);
+        frob_norm_square_loc += (mat.GetData()[i] * mat.GetData()[i]);
     }
     MPI_Allreduce(&frob_norm_square_loc, &frob_norm_square, 1, MPI_DOUBLE, MPI_SUM, comm);
     return std::sqrt(frob_norm_square);
@@ -121,6 +135,10 @@ int main(int argc, char* argv[])
         mfem::Mesh mesh(4, 4, 4, mfem::Element::HEXAHEDRON, 1);
         pmesh = make_unique<mfem::ParMesh>(comm, mesh);
     }
+    for (int i = 0; i < pmesh->GetNE(); i++)
+    {
+        pmesh->SetAttribute(i, i + 1);
+    }
     auto vertex_edge = TableToMatrix(pmesh->ElementToFaceTable());
     auto edge_bdratt = GenerateBoundaryAttributeTable(pmesh.get());
 
@@ -131,39 +149,36 @@ int main(int argc, char* argv[])
     int coarsening_factor = 8;
     PartitionAAT(vertex_edge, partitioning, coarsening_factor);
 
-    // Create an aggregate scaling function (agg scaling = agg number + 1)
-    mfem::Vector agg_scale(partitioning.Max() + 1);
-    for (int agg = 0; agg < agg_scale.Size(); agg++)
-    {
-        agg_scale(agg) = agg + 1;
-    }
+    //Create simple element and aggregate scaling
+    mfem::Vector elem_scale = SimpleAscendingScaling(pmesh->GetNE());
+    mfem::Vector agg_scale = SimpleAscendingScaling(partitioning.Max()+1);
 
-    // Create a fine level MixedMatrix corresponding to constant coefficient
-    auto fine_mgL = UnscaledFineMixedMatrix(sigmafespace, vertex_edge);
+    // Create a fine level MixedMatrix corresponding to piecewise constant coefficient
+    auto fine_mgL = OriginalScaledFineMatrix(sigmafespace, vertex_edge, elem_scale);
 
     // Create a coarsener to build interpolation matrices and coarse M builder
     auto coarsener = BuildCoarsener(vertex_edge, fine_mgL, partitioning, &edge_bdratt);
 
     // Interpolate agg scaling (coarse level) to elements (fine level)
-    mfem::Vector elem_scale(pmesh->GetNE());
+    mfem::Vector interp_agg_scale(pmesh->GetNE());
     auto part_mat = PartitionToMatrix(partitioning, agg_scale.Size());
-    part_mat.MultTranspose(agg_scale, elem_scale);
+    part_mat.MultTranspose(agg_scale, interp_agg_scale);
 
-    // Assemble scaled fine and coarse M through rescaling
-    fine_mgL.UpdateM(elem_scale);
+    // Assemble rescaled fine and coarse M through MixedMatrix
+    fine_mgL.UpdateM(interp_agg_scale);
     auto& fine_M1 = fine_mgL.GetM();
     auto coarse_mgL = coarsener->GetCoarse();
     coarse_mgL.UpdateM(agg_scale);
     auto& coarse_M1 = coarse_mgL.GetM();
 
-    // Assembled scaled fine and coarse M through direct assembling and RAP
-    auto fine_M2 = ScaledFineM(sigmafespace, elem_scale);
+    // Assembled rescaled fine and coarse M through direct assembling and RAP
+    auto fine_M2 = RescaledFineM(sigmafespace, elem_scale, interp_agg_scale);
     auto& Psigma = coarsener->get_Psigma();
     unique_ptr<mfem::SparseMatrix> coarse_M2(mfem::RAP(Psigma, fine_M2, Psigma));
 
     // Check relative differences measured in Frobenius norm
-    bool fine_rescale_fail = (RelativeDiff(comm, fine_M1, fine_M2) > 1e-10);
-    bool coarse_rescale_fail = (RelativeDiff(comm, coarse_M1, *coarse_M2) > 1e-10);
+    bool fine_rescale_fail = (RelativeDiff(comm, fine_M1, fine_M2) > 1e-16);
+    bool coarse_rescale_fail = (RelativeDiff(comm, coarse_M1, *coarse_M2) > 1e-16);
     if (myid == 0 && fine_rescale_fail)
     {
         std::cerr << "Fine level rescaling is NOT working as expected! \n";


### PR DESCRIPTION
While I was trying to use the rescaling feature in the two-phase flow code, where the M matrix will need to be updated during time stepping, I found that the coarse solution is not the same for serial and parallel run. So I trace back and realize the problem is when we compute the element matrices of coarse M, we used simple splitting (divided by 2) for the submatrices of M on faces (which is possibly the best one can do if only assembled fine M is given). But in the case when element matrices of fine M are available (through `FineMBuilder`), we can make use of it in the coarsening so that rescaling works for more general coefficients. This is the main purpose of this PR.

The test `rescaling.cpp` is also modified. It was testing rescaling fine/coarse M which was originally coming from finite volume problem with constant coefficient on uniform grid (note that in the case the divided by 2 strategy is doing the right job). The test now is modified to test rescaling fine/coarse M which is coming from FV problems with non-constant coefficient. 

   