### PR TITLE
modual vertex targets [general-eigenproblem]

### DIFF
--- a/src/GraphUpscale.cpp
+++ b/src/GraphUpscale.cpp
@@ -127,11 +127,11 @@ void GraphUpscale::MakeFineSolver()
     {
         if (param_.hybridization)
         {
-            solver_[0] = make_unique<HybridSolver>(comm_, GetFineMatrix());
+            solver_[0] = make_unique<HybridSolver>(comm_, GetMatrix(0));
         }
         else
         {
-            solver_[0] = make_unique<MinresBlockSolverFalse>(comm_, GetFineMatrix());
+            solver_[0] = make_unique<MinresBlockSolverFalse>(comm_, GetMatrix(0));
         }
     }
 }

--- a/src/LocalMixedGraphSpectralTargets.cpp
+++ b/src/LocalMixedGraphSpectralTargets.cpp
@@ -128,7 +128,7 @@ public:
         mfem::SparseMatrix& D_ext,
         mfem::SparseMatrix& M_ext, mfem::SparseMatrix& W_ext,
         bool scaled_dual, bool energy_dual);
-    
+
     /// returns minimum eigenvalue
     double ComputeEigenvectors(mfem::DenseMatrix& evects);
 
@@ -138,9 +138,9 @@ public:
                            mfem::DenseMatrix& AggExt_sigmaT);
 
 private:
-    void CheckMinimalEigenvalue(double eval_min, std::string entity); 
+    void CheckMinimalEigenvalue(double eval_min, std::string entity);
 
-   std::vector<mfem::SparseMatrix>
+    std::vector<mfem::SparseMatrix>
     BuildEdgeEigenSystem(
         const mfem::SparseMatrix& L,
         const mfem::SparseMatrix& D,
@@ -277,9 +277,6 @@ MixedBlockEigensystem::BuildEdgeEigenSystem(
 
     return EigSys;
 }
-
-//        bool no_edge_eigensystem = (!dual_target_ || use_w || max_evects_ == 1);
-//      bme.ComputeEdgeTraces(evects, !no_edge_eigensystem, AggExt_sigmaT[iAgg]);
 
 void MixedBlockEigensystem::ComputeEdgeTraces(mfem::DenseMatrix& evects,
                                               bool edge_eigensystem,
@@ -424,10 +421,6 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
 
     // SET W in eigenvalues
     const bool use_w = false && W_global_;
-    if (use_w)
-    {
-        // std::cout << "Warning: Using W in local eigensolves!\n";
-    }
 
     // ---
     // solve eigenvalue problem on each (extended) extended aggregate, our (3.1)
@@ -482,40 +475,6 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
                                   scaled_dual_, energy_dual_);
         mbe.ComputeEigenvectors(evects);
 
-/*
-        // extract local D correpsonding to iAgg-th extended aggregate
-        auto Dloc = ExtractRowAndColumns(D_ext, vertex_local_dof_ext,
-                                         edge_local_dof_ext, colMapper_) ;
-        Mloc_diag_inv.SetSize(edge_local_dof_ext.Size());
-        for (int i = 0; i < Dloc.Width(); i++)
-        {
-            Mloc_diag_inv(i) = 1.0 / M_diag_data[edge_local_dof_ext[i]];
-        }
-
-        // build local (weighted) graph Laplacian (assumed diagonal M, key difference in multilevel setting)
-        mfem::SparseMatrix DlocT = smoothg::Transpose(Dloc);
-        DlocT.ScaleRows(Mloc_diag_inv);
-        mfem::SparseMatrix DMinvDt = smoothg::Mult(Dloc, DlocT);
-
-        // Wloc assumed to be diagonal
-        if (use_w)
-        {
-            auto Wloc = ExtractRowAndColumns(W_ext, vertex_local_dof_ext,
-                                             vertex_local_dof_ext, colMapper_) ;
-            assert(Wloc.NumNonZeroElems() == Wloc.Height());
-            assert(Wloc.Height() == Wloc.Width());
-
-            DMinvDt.Add(-1.0, Wloc);
-        }
-
-        // actually solve (3.1)
-        double eval_min = eigs.Compute(DMinvDt, evects);
-        if (!use_w)
-        {
-            CheckMinimalEigenvalue(eval_min, iAgg, "vertex");
-        }
-*/
-
         int nevects = evects.Width();
         if (use_w)
         {
@@ -526,9 +485,7 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
             constant = 1.0 / std::sqrt(evects.Height());
 
             Concatenate(constant, evects, out);
-
             evects = out;
-
             nevects++;
         }
 
@@ -552,38 +509,6 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
         bool no_edge_eigensystem = (!dual_target_ || use_w || max_evects_ == 1);
         mbe.ComputeEdgeTraces(evects, !no_edge_eigensystem, AggExt_sigmaT[iAgg]);
     }
-
-/*
-        if (!dual_target_ || use_w || max_evects_ == 1)
-        {
-            // Do not consider the first vertex eigenvector, which is constant
-            evects_tmp.UseExternalData(evects.Data() + evects.Height(),
-                                       evects.Height(), nevects - 1);
-
-            // Collect trace samples from M^{-1}Dloc^T times vertex eigenvectors
-            // transposed for extraction later
-            AggExt_sigmaT[iAgg].SetSize(evects_tmp.Width(), DlocT.Height());
-            MultSparseDenseTranspose(DlocT, evects_tmp, AggExt_sigmaT[iAgg]);
-        }
-        else
-        {
-            // Collect trace samples from eigenvectors of dual graph Laplacian
-            auto EES = BuildEdgeEigenSystem(DMinvDt, Dloc, Mloc_diag_inv);
-            if (energy_dual_)
-            {
-                eval_min = eigs.Compute(EES[0], EES[1], evects);
-            }
-            else
-            {
-                eval_min = eigs.Compute(EES[0], evects);
-            }
-            CheckMinimalEigenvalue(eval_min, iAgg, "edge");
-
-            // Transpose all edge eigenvectors for extraction later
-            AggExt_sigmaT[iAgg].Transpose(evects);
-        }
-    }
-*/
 }
 
 void LocalMixedGraphSpectralTargets::ComputeEdgeTargets(

--- a/src/LocalMixedGraphSpectralTargets.cpp
+++ b/src/LocalMixedGraphSpectralTargets.cpp
@@ -22,7 +22,6 @@
 #include "GraphCoarsen.hpp"
 #include "utilities.hpp"
 #include "sharedentitycommunication.hpp"
-#include "LocalEigenSolver.hpp"
 #include "MatrixUtilities.hpp"
 
 using std::unique_ptr;
@@ -115,8 +114,119 @@ LocalMixedGraphSpectralTargets::LocalMixedGraphSpectralTargets(
     }
 }
 
+/// just extracting / modularizing some code from ComputeVertexTargets()
+/// @todo way too many arguments, lots of refactoring possible here
+/// (note that both evects and Mloc_diag_inv are output arguments, the
+///  rest are input)
+class MixedBlockEigensystem
+{
+public:
+    MixedBlockEigensystem(
+        const mfem::Array<int>& vertex_local_dof_ext,
+        const mfem::Array<int>& edge_local_dof_ext,
+        LocalEigenSolver& eigs, mfem::Array<int>& colMapper,
+        mfem::SparseMatrix& D_ext,
+        mfem::SparseMatrix& M_ext, mfem::SparseMatrix& W_ext,
+        bool scaled_dual, bool energy_dual);
+    
+    /// returns minimum eigenvalue
+    double ComputeEigenvectors(mfem::DenseMatrix& evects);
+
+    /// @todo should scaled_dual and energy_dual be arguments here?
+    void ComputeEdgeTraces(mfem::DenseMatrix& evects,
+                           bool edge_eigensystem,
+                           mfem::DenseMatrix& AggExt_sigmaT);
+
+private:
+    void CheckMinimalEigenvalue(double eval_min, std::string entity); 
+
+   std::vector<mfem::SparseMatrix>
+    BuildEdgeEigenSystem(
+        const mfem::SparseMatrix& L,
+        const mfem::SparseMatrix& D,
+        const mfem::Vector& M_diag_inv);
+
+    LocalEigenSolver& eigs_;
+    bool use_w_;
+    mfem::SparseMatrix Dloc_;
+    mfem::SparseMatrix DlocT_;
+    mfem::SparseMatrix DMinvDt_;
+    mfem::Vector Mloc_diag_inv_;
+    bool scaled_dual_;
+    bool energy_dual_;
+    double zero_eigenvalue_threshold_;
+};
+
+void MixedBlockEigensystem::CheckMinimalEigenvalue(
+    double eval_min, std::string entity)
+{
+    if (fabs(eval_min) > zero_eigenvalue_threshold_)
+    {
+        // std::cerr << "Aggregate id: " << aggregate_id << "\n";
+        std::cerr << "Smallest eigenvalue: " << eval_min << "\n";
+        auto msg = "Smallest eigenvalue of " + entity + " Laplacian is nonzero!";
+        mfem::mfem_error(msg.c_str());
+    }
+}
+
+MixedBlockEigensystem::MixedBlockEigensystem(
+    const mfem::Array<int>& vertex_local_dof_ext,
+    const mfem::Array<int>& edge_local_dof_ext,
+    LocalEigenSolver& eigs, mfem::Array<int>& colMapper,
+    mfem::SparseMatrix& D_ext,
+    mfem::SparseMatrix& M_ext, mfem::SparseMatrix& W_ext,
+    bool scaled_dual, bool energy_dual)
+    :
+    eigs_(eigs),
+    use_w_((W_ext.Height() > 0)),
+    scaled_dual_(scaled_dual),
+    energy_dual_(energy_dual),
+    zero_eigenvalue_threshold_(1.e-8)
+{
+    const double* M_diag_data = M_ext.GetData();
+
+    // extract local D corresponding to iAgg-th extended aggregate
+    mfem::SparseMatrix Dloc_tmp =
+        ExtractRowAndColumns(D_ext, vertex_local_dof_ext, edge_local_dof_ext, colMapper);
+    Dloc_.Swap(Dloc_tmp);
+    Mloc_diag_inv_.SetSize(edge_local_dof_ext.Size());
+    for (int i = 0; i < Dloc_.Width(); i++)
+    {
+        Mloc_diag_inv_(i) = 1.0 / M_diag_data[edge_local_dof_ext[i]];
+    }
+
+    // build local (weighted) graph Laplacian (assumed diagonal M, key difference in multilevel setting)
+    mfem::SparseMatrix DlocT_tmp = smoothg::Transpose(Dloc_);
+    DlocT_.Swap(DlocT_tmp);
+    DlocT_.ScaleRows(Mloc_diag_inv_);
+    mfem::SparseMatrix DMinvDt_tmp = smoothg::Mult(Dloc_, DlocT_);
+    DMinvDt_.Swap(DMinvDt_tmp);
+
+    // Wloc assumed to be diagonal
+    if (use_w_)
+    {
+        auto Wloc = ExtractRowAndColumns(W_ext, vertex_local_dof_ext,
+                                         vertex_local_dof_ext, colMapper) ;
+        assert(Wloc.NumNonZeroElems() == Wloc.Height());
+        assert(Wloc.Height() == Wloc.Width());
+
+        DMinvDt_.Add(-1.0, Wloc);
+    }
+}
+
+double MixedBlockEigensystem::ComputeEigenvectors(mfem::DenseMatrix& evects)
+{
+    // actually solve (3.1)
+    double eval_min = eigs_.Compute(DMinvDt_, evects);
+    if (!use_w_)
+    {
+        CheckMinimalEigenvalue(eval_min, "vertex");
+    }
+    return eval_min;
+}
+
 std::vector<mfem::SparseMatrix>
-LocalMixedGraphSpectralTargets::BuildEdgeEigenSystem(
+MixedBlockEigensystem::BuildEdgeEigenSystem(
     const mfem::SparseMatrix& L,
     const mfem::SparseMatrix& D,
     const mfem::Vector& M_diag_inv)
@@ -168,27 +278,46 @@ LocalMixedGraphSpectralTargets::BuildEdgeEigenSystem(
     return EigSys;
 }
 
-void LocalMixedGraphSpectralTargets::CheckMinimalEigenvalue(
-    double eval_min, int aggregate_id, std::string entity)
+//        bool no_edge_eigensystem = (!dual_target_ || use_w || max_evects_ == 1);
+//      bme.ComputeEdgeTraces(evects, !no_edge_eigensystem, AggExt_sigmaT[iAgg]);
+
+void MixedBlockEigensystem::ComputeEdgeTraces(mfem::DenseMatrix& evects,
+                                              bool edge_eigensystem,
+                                              mfem::DenseMatrix& AggExt_sigmaT)
 {
-    if (fabs(eval_min) > zero_eigenvalue_threshold_)
+    const int nevects = evects.Width();
+    if (!edge_eigensystem)
     {
-        std::cerr << "Aggregate id: " << aggregate_id << "\n";
-        std::cout << "Smallest eigenvalue: " << eval_min << "\n";
-        auto msg = "Smallest eigenvalue of " + entity + " Laplacian is nonzero!";
-        mfem::mfem_error(msg.c_str());
+        mfem::DenseMatrix evects_tmp;
+        // Do not consider the first vertex eigenvector, which is constant
+        evects_tmp.UseExternalData(evects.Data() + evects.Height(),
+                                   evects.Height(), nevects - 1);
+
+        // Collect trace samples from M^{-1}Dloc^T times vertex eigenvectors
+        // transposed for extraction later
+        AggExt_sigmaT.SetSize(evects_tmp.Width(), DlocT_.Height());
+        MultSparseDenseTranspose(DlocT_, evects_tmp, AggExt_sigmaT);
+    }
+    else
+    {
+        double eval_min = 0.0;
+        // Collect trace samples from eigenvectors of dual graph Laplacian
+        auto EES = BuildEdgeEigenSystem(DMinvDt_, Dloc_, Mloc_diag_inv_);
+        if (energy_dual_)
+        {
+            eval_min = eigs_.Compute(EES[0], EES[1], evects);
+        }
+        else
+        {
+            eval_min = eigs_.Compute(EES[0], evects);
+        }
+        CheckMinimalEigenvalue(eval_min, "edge");
+
+        // Transpose all edge eigenvectors for extraction later
+        AggExt_sigmaT.Transpose(evects);
     }
 }
 
-/*
-/// just extracting some code from ComputeVertexTargets()
-void LocalMixedGraphSpectralTargets::BlockEigensystem(
-    const mfem::Array<int>& vertex_local_dof_ext,
-    const mfem::Array<int>& edge_local_dof_ext,
-    colMapper, eigs, D_ext, M_ext, W_ext, evects)
-{
-}
-*/
 
 void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
     std::vector<mfem::DenseMatrix>& AggExt_sigmaT,
@@ -289,10 +418,9 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
 
     mfem::Array<int> vertex_local_dof;
     mfem::Array<int> diag_loc_dof, offd_loc_dof;
-    mfem::Vector first_evect, Mloc_diag_inv;
+    mfem::Vector first_evect;
     mfem::DenseMatrix evects, evects_tmp, evects_restricted;
     mfem::DenseMatrix evects_T, evects_restricted_T;
-    const double* M_diag_data = M_ext.GetData();
 
     // SET W in eigenvalues
     const bool use_w = false && W_global_;
@@ -349,11 +477,12 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
             continue;
         }
 
-        /*
-                BlockEigensystem(vertex_local_dof_ext, edge_local_dof_ext,
-                                 colMapper_, eigs, D_ext, M_ext, W_ext, evects);
-        */
+        MixedBlockEigensystem mbe(vertex_local_dof_ext, edge_local_dof_ext,
+                                  eigs, colMapper_, D_ext, M_ext, W_ext,
+                                  scaled_dual_, energy_dual_);
+        mbe.ComputeEigenvectors(evects);
 
+/*
         // extract local D correpsonding to iAgg-th extended aggregate
         auto Dloc = ExtractRowAndColumns(D_ext, vertex_local_dof_ext,
                                          edge_local_dof_ext, colMapper_) ;
@@ -385,6 +514,7 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
         {
             CheckMinimalEigenvalue(eval_min, iAgg, "vertex");
         }
+*/
 
         int nevects = evects.Width();
         if (use_w)
@@ -419,6 +549,11 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
         Orthogonalize(evects_restricted, first_evect, 1, local_vertex_targets[iAgg]);
 
         // Compute edge trace samples (before restriction and SVD)
+        bool no_edge_eigensystem = (!dual_target_ || use_w || max_evects_ == 1);
+        mbe.ComputeEdgeTraces(evects, !no_edge_eigensystem, AggExt_sigmaT[iAgg]);
+    }
+
+/*
         if (!dual_target_ || use_w || max_evects_ == 1)
         {
             // Do not consider the first vertex eigenvector, which is constant
@@ -448,6 +583,7 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
             AggExt_sigmaT[iAgg].Transpose(evects);
         }
     }
+*/
 }
 
 void LocalMixedGraphSpectralTargets::ComputeEdgeTargets(

--- a/src/LocalMixedGraphSpectralTargets.cpp
+++ b/src/LocalMixedGraphSpectralTargets.cpp
@@ -116,8 +116,6 @@ LocalMixedGraphSpectralTargets::LocalMixedGraphSpectralTargets(
 
 /// just extracting / modularizing some code from ComputeVertexTargets()
 /// @todo way too many arguments, lots of refactoring possible here
-/// (note that both evects and Mloc_diag_inv are output arguments, the
-///  rest are input)
 class MixedBlockEigensystem
 {
 public:

--- a/src/LocalMixedGraphSpectralTargets.hpp
+++ b/src/LocalMixedGraphSpectralTargets.hpp
@@ -234,7 +234,7 @@ private:
     mfem::Array<HYPRE_Int> D_local_rowstart;
     mfem::Array<HYPRE_Int> edge_ext_start;
 
-    mfem::Array<int> colMapper;
+    mfem::Array<int> colMapper_;
 };
 
 } // namespace smoothg

--- a/src/LocalMixedGraphSpectralTargets.hpp
+++ b/src/LocalMixedGraphSpectralTargets.hpp
@@ -198,11 +198,6 @@ private:
     void ComputeEdgeTargets(const std::vector<mfem::DenseMatrix>& AggExt_sigmaT,
                             std::vector<mfem::DenseMatrix>& local_edge_trace_targets);
 
-    // std::vector<mfem::SparseMatrix> BuildEdgeEigenSystem(
-    //   const mfem::SparseMatrix& Lloc,
-    //   const mfem::SparseMatrix& Dloc,
-    //   const mfem::Vector& Mloc_diag_inv);
-
     void Orthogonalize(mfem::DenseMatrix& vectors, mfem::Vector& single_vec,
                        int offset, mfem::DenseMatrix& out);
 

--- a/src/LocalMixedGraphSpectralTargets.hpp
+++ b/src/LocalMixedGraphSpectralTargets.hpp
@@ -30,6 +30,7 @@
 
 #include "mfem.hpp"
 #include "GraphTopology.hpp"
+#include "LocalEigenSolver.hpp"
 
 namespace smoothg
 {
@@ -197,16 +198,13 @@ private:
     void ComputeEdgeTargets(const std::vector<mfem::DenseMatrix>& AggExt_sigmaT,
                             std::vector<mfem::DenseMatrix>& local_edge_trace_targets);
 
-    std::vector<mfem::SparseMatrix> BuildEdgeEigenSystem(
-        const mfem::SparseMatrix& Lloc,
-        const mfem::SparseMatrix& Dloc,
-        const mfem::Vector& Mloc_diag_inv);
+    // std::vector<mfem::SparseMatrix> BuildEdgeEigenSystem(
+    //   const mfem::SparseMatrix& Lloc,
+    //   const mfem::SparseMatrix& Dloc,
+    //   const mfem::Vector& Mloc_diag_inv);
 
     void Orthogonalize(mfem::DenseMatrix& vectors, mfem::Vector& single_vec,
                        int offset, mfem::DenseMatrix& out);
-
-    void CheckMinimalEigenvalue(
-        double eval_min, int aggregate_id, std::string entity);
 
     MPI_Comm comm_;
 


### PR DESCRIPTION
The idea is to construct vertex targets / solve eigenproblem in slightly more modular way.

This will allow for future generalization with non-diagonal M for multilevel implementation.

This PR builds on multilevel data structures PR #27 and that PR should be reviewed before this one - after it is merged this one's diff will look nicer.