### PR TITLE
Local saddle point solver and assembling of coarse operators for general M

### DIFF
--- a/examples/finitevolume.cpp
+++ b/examples/finitevolume.cpp
@@ -186,18 +186,21 @@ int main(int argc, char* argv[])
     rhs_fine.GetBlock(0) = 0.0;
     rhs_fine.GetBlock(1) = rhs_u_fine;
 
-    auto sol_upscaled = fvupscale.Solve(rhs_fine);
-    fvupscale.ShowSolveInfo(1);
-
-    auto sol_fine = fvupscale.SolveFine(rhs_fine);
-    fvupscale.ShowSolveInfo(0);
-
-    auto error_info = fvupscale.ComputeErrors(sol_upscaled, sol_fine);
-
-    if (myid == 0)
+    /// [Solve]
+    std::vector<mfem::BlockVector> sol(upscale_param.max_levels, rhs_fine);
+    for (int level = 0; level < upscale_param.max_levels; ++level)
     {
-        ShowErrors(error_info);
+        fvupscale.Solve(level, rhs_fine, sol[level]);
+        fvupscale.ShowSolveInfo(level);
+
+        auto error_info = fvupscale.ComputeErrors(sol[level], sol[0]);
+
+        if (level > 0 && myid == 0)
+        {
+            ShowErrors(error_info);
+        }
     }
+    /// [Solve]
 
     // Visualize the solution
     if (visualization)
@@ -232,8 +235,10 @@ int main(int argc, char* argv[])
             MPI_Barrier(comm);
         };
 
-        Visualize(sol_upscaled.GetBlock(1));
-        Visualize(sol_fine.GetBlock(1));
+        for (int level = 0; level < upscale_param.max_levels; ++level)
+        {
+            Visualize(sol[level].GetBlock(1));
+        }
     }
 
     return EXIT_SUCCESS;

--- a/examples/generalgraph.cpp
+++ b/examples/generalgraph.cpp
@@ -190,16 +190,20 @@ int main(int argc, char* argv[])
         /// [Right Hand Side]
 
         /// [Solve]
-        mfem::BlockVector upscaled_sol = upscale.Solve(fine_rhs);
-        upscale.ShowSolveInfo(1);
+        std::vector<mfem::BlockVector> sol(upscale_param.max_levels, fine_rhs);
+        for (int level = 0; level < upscale_param.max_levels; ++level)
+        {
+            upscale.Solve(level, fine_rhs, sol[level]);
+            upscale.ShowSolveInfo(level);
 
-        mfem::BlockVector fine_sol = upscale.SolveFine(fine_rhs);
-        upscale.ShowSolveInfo(0);
+            auto error_info = upscale.ComputeErrors(sol[level], sol[0]);
+
+            if (level > 0 && myid == 0)
+            {
+                ShowErrors(error_info);
+            }
+        }
         /// [Solve]
-
-        /// [Check Error]
-        upscale.ShowErrors(upscaled_sol, fine_sol);
-        /// [Check Error]
 
         if (save_fiedler)
         {

--- a/src/FiniteVolumeUpscale.cpp
+++ b/src/FiniteVolumeUpscale.cpp
@@ -44,6 +44,7 @@ FiniteVolumeUpscale::FiniteVolumeUpscale(MPI_Comm comm,
     solver_.resize(param.max_levels);
     rhs_.resize(param_.max_levels);
     sol_.resize(param_.max_levels);
+    std::vector<GraphTopology> gts;
 
     // Hypre may modify the original vertex_edge, which we seek to avoid
     mfem::SparseMatrix ve_copy(vertex_edge);
@@ -51,46 +52,69 @@ FiniteVolumeUpscale::FiniteVolumeUpscale(MPI_Comm comm,
     mixed_laplacians_.emplace_back(vertex_edge, weight, edge_d_td_,
                                    MixedMatrix::DistributeWeight::False);
 
-    GraphTopology gt(ve_copy, edge_d_td_, partitioning, &edge_boundary_att_);
-    coarsener_.emplace_back(make_unique<SpectralAMG_MGL_Coarsener>(
-                                mixed_laplacians_[0], std::move(gt), param));
-    coarsener_[0]->construct_coarse_subspace(GetConstantRep(0));
+    gts.emplace_back(ve_copy, edge_d_td_, partitioning, &edge_boundary_att_);
 
-    mixed_laplacians_.push_back(coarsener_[0]->GetCoarse());
+    // coarser levels: topology
+    for (int level = 2; level < param_.max_levels; ++level)
+    {
+        gts.emplace_back(gts.back(), param_.coarse_factor);
+    }
+
+    // coarser levels: matrices
+    for (int level = 1; level < param_.max_levels; ++level)
+    {
+        coarsener_.emplace_back(make_unique<SpectralAMG_MGL_Coarsener>(
+                                    mixed_laplacians_[level - 1],
+                                    std::move(gts[level - 1]), param_));
+        coarsener_[level - 1]->construct_coarse_subspace(GetConstantRep(level - 1));
+
+        mixed_laplacians_.push_back(coarsener_[level - 1]->GetCoarse());
+
+        if (level < param_.max_levels - 1 || !param_.hybridization)
+        {
+            mixed_laplacians_.back().BuildM();
+        }
+    }
+
+    // fine level: solver
+    MakeFineSolver();
     MakeVectors(0);
 
-    mfem::SparseMatrix& Dref = GetMatrix(1).GetD();
-    mfem::Array<int> marker(Dref.Width());
-    marker = 0;
-
-    MarkDofsOnBoundary(coarsener_[0]->get_GraphTopology_ref().face_bdratt_,
-                       coarsener_[0]->construct_face_facedof_table(),
-                       ess_attr, marker);
-
-    if (param_.hybridization) // Hybridization solver
+    // coarser levels: solver
+    for (int level = 1; level < param_.max_levels; ++level)
     {
-        auto face_bdratt = coarsener_[0]->get_GraphTopology_ref().face_bdratt_;
-        solver_[1] = make_unique<HybridSolver>(
-                         comm, mixed_laplacians_.back(), *coarsener_[0],
-                         &face_bdratt, &marker, 0, param_.saamge_param);
-    }
-    else // L2-H1 block diagonal preconditioner
-    {
-        GetMatrix(1).BuildM();
-        mfem::SparseMatrix& Mref = GetMatrix(1).GetM();
-        for (int mm = 0; mm < marker.Size(); ++mm)
+        mfem::SparseMatrix& Dref = GetMatrix(level).GetD();
+        mfem::Array<int> marker(Dref.Width());
+        marker = 0;
+
+        MarkDofsOnBoundary(coarsener_[level - 1]->get_GraphTopology_ref().face_bdratt_,
+                           coarsener_[level - 1]->construct_face_facedof_table(),
+                           ess_attr, marker);
+
+        if (param_.hybridization) // Hybridization solver
         {
-            // Assume M diagonal, no ess data
-            if (marker[mm])
-                Mref.EliminateRow(mm, true);
+            auto face_bdratt = coarsener_[level - 1]->get_GraphTopology_ref().face_bdratt_;
+            solver_[level] = make_unique<HybridSolver>(
+                                 comm, GetMatrix(level), *coarsener_[level - 1],
+                                 &face_bdratt, &marker, 0, param_.saamge_param);
         }
+        else // L2-H1 block diagonal preconditioner
+        {
+            GetMatrix(level).BuildM();
+            mfem::SparseMatrix& Mref = GetMatrix(level).GetM();
+            for (int mm = 0; mm < marker.Size(); ++mm)
+            {
+                // Assume M diagonal, no ess data
+                if (marker[mm])
+                    Mref.EliminateRow(mm, true);
+            }
 
-        Dref.EliminateCols(marker);
+            Dref.EliminateCols(marker);
 
-        solver_[1] = make_unique<MinresBlockSolverFalse>(comm, GetMatrix(1));
+            solver_[level] = make_unique<MinresBlockSolverFalse>(comm, GetMatrix(level));
+        }
+        MakeVectors(level);
     }
-
-    MakeVectors(1);
 
     chrono.Stop();
     setup_time_ += chrono.RealTime();
@@ -117,6 +141,7 @@ FiniteVolumeUpscale::FiniteVolumeUpscale(MPI_Comm comm,
     solver_.resize(param.max_levels);
     rhs_.resize(param_.max_levels);
     sol_.resize(param_.max_levels);
+    std::vector<GraphTopology> gts;
 
     // Hypre may modify the original vertex_edge, which we seek to avoid
     mfem::SparseMatrix ve_copy(vertex_edge);
@@ -124,47 +149,68 @@ FiniteVolumeUpscale::FiniteVolumeUpscale(MPI_Comm comm,
     mixed_laplacians_.emplace_back(vertex_edge, weight, w_block, edge_d_td_,
                                    MixedMatrix::DistributeWeight::False);
 
-    GraphTopology gt(ve_copy, edge_d_td_, partitioning, &edge_boundary_att_);
+    gts.emplace_back(ve_copy, edge_d_td_, partitioning, &edge_boundary_att_);
 
-    coarsener_.emplace_back(make_unique<SpectralAMG_MGL_Coarsener>(
-                                mixed_laplacians_[0], std::move(gt), param_));
-    coarsener_[0]->construct_coarse_subspace(GetConstantRep(0));
+    // coarser levels: topology
+    for (int level = 2; level < param_.max_levels; ++level)
+    {
+        gts.emplace_back(gts.back(), param_.coarse_factor);
+    }
 
-    mixed_laplacians_.push_back(coarsener_[0]->GetCoarse());
+    // coarser levels: matrices
+    for (int level = 1; level < param_.max_levels; ++level)
+    {
+        coarsener_.emplace_back(make_unique<SpectralAMG_MGL_Coarsener>(
+                                    mixed_laplacians_[level - 1],
+                                    std::move(gts[level - 1]), param_));
+        coarsener_[level - 1]->construct_coarse_subspace(GetConstantRep(level - 1));
+
+        mixed_laplacians_.push_back(coarsener_[level - 1]->GetCoarse());
+        if (level < param_.max_levels - 1 || !param_.hybridization)
+        {
+            mixed_laplacians_.back().BuildM();
+        }
+    }
+
+    // fine level: solver
+    MakeFineSolver();
     MakeVectors(0);
 
-    mfem::SparseMatrix& Dref = GetMatrix(1).GetD();
-    mfem::Array<int> marker(Dref.Width());
-    marker = 0;
-
-    MarkDofsOnBoundary(coarsener_[0]->get_GraphTopology_ref().face_bdratt_,
-                       coarsener_[0]->construct_face_facedof_table(),
-                       ess_attr, marker);
-
-    if (param_.hybridization) // Hybridization solver
+    // coarser levels: solver
+    for (int level = 1; level < param_.max_levels; ++level)
     {
-        auto face_bdratt = coarsener_[0]->get_GraphTopology_ref().face_bdratt_;
-        solver_[1] = make_unique<HybridSolver>(
-                         comm, mixed_laplacians_.back(), *coarsener_[0],
-                         &face_bdratt, &marker, 0, param_.saamge_param);
-    }
-    else // L2-H1 block diagonal preconditioner
-    {
-        GetMatrix(1).BuildM();
-        mfem::SparseMatrix& Mref = GetMatrix(1).GetM();
-        for (int mm = 0; mm < marker.Size(); ++mm)
+        mfem::SparseMatrix& Dref = GetMatrix(level).GetD();
+        mfem::Array<int> marker(Dref.Width());
+        marker = 0;
+
+        MarkDofsOnBoundary(coarsener_[level - 1]->get_GraphTopology_ref().face_bdratt_,
+                           coarsener_[level - 1]->construct_face_facedof_table(),
+                           ess_attr, marker);
+
+        if (param_.hybridization) // Hybridization solver
         {
-            // Assume M diagonal, no ess data
-            if (marker[mm])
-                Mref.EliminateRow(mm, true);
+            auto face_bdratt = coarsener_[level - 1]->get_GraphTopology_ref().face_bdratt_;
+            solver_[level] = make_unique<HybridSolver>(
+                                 comm, GetMatrix(level), *coarsener_[level - 1],
+                                 &face_bdratt, &marker, 0, param_.saamge_param);
         }
+        else // L2-H1 block diagonal preconditioner
+        {
+            GetMatrix(level).BuildM();
+            mfem::SparseMatrix& Mref = GetMatrix(level).GetM();
+            for (int mm = 0; mm < marker.Size(); ++mm)
+            {
+                // Assume M diagonal, no ess data
+                if (marker[mm])
+                    Mref.EliminateRow(mm, true);
+            }
 
-        Dref.EliminateCols(marker);
+            Dref.EliminateCols(marker);
 
-        solver_[1] = make_unique<MinresBlockSolverFalse>(comm, mixed_laplacians_.back());
+            solver_[level] = make_unique<MinresBlockSolverFalse>(comm, GetMatrix(level));
+        }
+        MakeVectors(level);
     }
-
-    MakeVectors(1);
 
     chrono.Stop();
     setup_time_ += chrono.RealTime();

--- a/src/FiniteVolumeUpscale.cpp
+++ b/src/FiniteVolumeUpscale.cpp
@@ -106,7 +106,7 @@ FiniteVolumeUpscale::FiniteVolumeUpscale(MPI_Comm comm,
             {
                 // Assume M diagonal, no ess data
                 if (marker[mm])
-                    Mref.EliminateRow(mm, true);
+                    Mref.EliminateRowCol(mm, true);
             }
 
             Dref.EliminateCols(marker);

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -176,6 +176,12 @@ void GraphCoarsen::NormalizeTraces(std::vector<mfem::DenseMatrix>& edge_traces,
         edge_traces_f.GetColumnReference(0, PV_trace);
         double oneDpv = Dtransfer.InnerProduct(PV_trace, localconstant);
 
+        if (fabs(oneDpv) < 1e-10)
+        {
+            std::cout << "Warning: oneDpv is closed to zero, oneDpv = "
+                      << oneDpv << ", this may be due to bad PV traces!\n";
+        }
+
         if (oneDpv < 0)
         {
             sign_flip = true;
@@ -489,6 +495,7 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
                         if (loc_map.first != other_j && loc_map.first != j)
                         {
                             other_j = loc_map.first;
+                            // TODO: avoid repeated extraction in high order coarsening
                             auto tmp = ExtractRowAndColumns(M_proc_, facefdofs[j],
                                                             facefdofs[other_j], colMapper_);
                             Mbb.Swap(tmp);

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -367,7 +367,7 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
     mfem::Vector local_rhs_trace0, local_rhs_trace1, local_rhs_bubble, local_sol, trace;
     mfem::Array<int> local_verts, local_fine_dofs, faces;
     mfem::Array<int> facecdofs, local_facecdofs;
-    mfem::Vector one;
+    mfem::Vector one, first_vert_target;
     mfem::SparseMatrix Mbb;
     for (unsigned int i = 0; i < nAggs; i++)
     {
@@ -388,7 +388,6 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
         local_rhs_trace1.SetSize(nlocal_verts);
 
         mfem::DenseMatrix& vertex_target_i(vertex_target[i]);
-        double scale = vertex_target_i(0, 0);
 
         // ---
         // solving bubble functions (vertex_target -> bubbles)
@@ -454,8 +453,9 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
                 // compute and store local coarse D
                 if (k == 0)
                 {
+                    vertex_target_i.GetColumnReference(0, first_vert_target);
                     CoarseD_->Set(bubble_counter + i, row,
-                                  local_rhs_trace1.Sum() * -1.*scale);
+                                  (local_rhs_trace1 * first_vert_target) * -1.);
                 }
 
                 // instead of doing local_rhs *= -1, we store -trace later

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -178,7 +178,7 @@ void GraphCoarsen::NormalizeTraces(std::vector<mfem::DenseMatrix>& edge_traces,
 
         if (fabs(oneDpv) < 1e-10)
         {
-            std::cout << "Warning: oneDpv is closed to zero, oneDpv = "
+            std::cerr << "Warning: oneDpv is closed to zero, oneDpv = "
                       << oneDpv << ", this may be due to bad PV traces!\n";
         }
 

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -482,19 +482,20 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
                     int other_j = -1;
                     for (int l = 0; l < nlocal_traces; l++)
                     {
+                        entry_value = DTTraceProduct(DtransferT, F_potentials, l, trace);
+                        entry_value -= DTTraceProduct(MtransferT, traces_extensions, l, trace);
+
                         std::pair<int, int>& loc_map = agg_trace_map[l];
-                        if (loc_map.first != other_j)
+                        if (loc_map.first != other_j && loc_map.first != j)
                         {
                             other_j = loc_map.first;
                             auto tmp = ExtractRowAndColumns(M_proc_, facefdofs[j],
                                                             facefdofs[other_j], colMapper_);
                             Mbb.Swap(tmp);
+                            entry_value += DTTraceProduct(Mbb, edge_traces[faces[other_j]],
+                                                          loc_map.second, trace);
                         }
 
-                        entry_value = DTTraceProduct(DtransferT, F_potentials, l, trace);
-                        entry_value -= DTTraceProduct(MtransferT, traces_extensions, l, trace);
-                        entry_value += DTTraceProduct(Mbb, edge_traces[faces[other_j]],
-                                                      loc_map.second, trace);
                         coarse_mbuilder.AddTraceTraceBlock(local_facecdofs[l], entry_value);
                     }
                 }

--- a/src/GraphCoarsenBuilder.cpp
+++ b/src/GraphCoarsenBuilder.cpp
@@ -130,14 +130,14 @@ void ElementMBuilder::SetTraceBubbleBlock(int l, double value)
 
 void ElementMBuilder::AddTraceTraceBlockDiag(double value)
 {
-    M_el_[agg_index_](dof_loc_, dof_loc_) = value;
+    M_el_[agg_index_](dof_loc_, dof_loc_) += value;
 }
 
 void ElementMBuilder::AddTraceTraceBlock(int l, double value)
 {
     mfem::DenseMatrix& M_el_loc(M_el_[agg_index_]);
-    M_el_loc(edge_dof_markers_[0][l], dof_loc_) = value;
-    M_el_loc(dof_loc_, edge_dof_markers_[0][l]) = value;
+    M_el_loc(edge_dof_markers_[0][l], dof_loc_) += value;
+    M_el_loc(dof_loc_, edge_dof_markers_[0][l]) += value;
 }
 
 void ElementMBuilder::SetBubbleBubbleBlock(int l, int j, double value)

--- a/src/GraphTopology.cpp
+++ b/src/GraphTopology.cpp
@@ -88,7 +88,17 @@ GraphTopology::GraphTopology(GraphTopology& finer_graph_topology, int coarsening
                                    &(finer_graph_topology.face_bdratt_) : nullptr;
 
     mfem::Array<int> partitioning;
-    PartitionAAT(vertex_edge, partitioning, coarsening_factor); // actual partition happens
+//    PartitionAAT(vertex_edge, partitioning, coarsening_factor); // actual partition happens
+
+    partitioning.SetSize(vertex_edge.Height());
+    int partitions = partitioning.Size() / coarsening_factor;
+    for (int p = 0; p < partitions; ++p)
+    {
+        for (int i = p * coarsening_factor; i < (p + 1) * coarsening_factor; ++i)
+        {
+            partitioning[i] = p;
+        }
+    }
 
     const auto edge_d_td_d_ptr = finer_graph_topology.face_d_td_d_.get();
     Init(vertex_edge, partitioning, edge_boundaryattr, edge_d_td_d_ptr);

--- a/src/GraphTopology.cpp
+++ b/src/GraphTopology.cpp
@@ -88,17 +88,7 @@ GraphTopology::GraphTopology(GraphTopology& finer_graph_topology, int coarsening
                                    &(finer_graph_topology.face_bdratt_) : nullptr;
 
     mfem::Array<int> partitioning;
-//    PartitionAAT(vertex_edge, partitioning, coarsening_factor); // actual partition happens
-
-    partitioning.SetSize(vertex_edge.Height());
-    int partitions = partitioning.Size() / coarsening_factor;
-    for (int p = 0; p < partitions; ++p)
-    {
-        for (int i = p * coarsening_factor; i < (p + 1) * coarsening_factor; ++i)
-        {
-            partitioning[i] = p;
-        }
-    }
+    PartitionAAT(vertex_edge, partitioning, coarsening_factor); // actual partition happens
 
     const auto edge_d_td_d_ptr = finer_graph_topology.face_d_td_d_.get();
     Init(vertex_edge, partitioning, edge_boundaryattr, edge_d_td_d_ptr);

--- a/src/GraphUpscale.cpp
+++ b/src/GraphUpscale.cpp
@@ -96,13 +96,11 @@ void GraphUpscale::Init(const mfem::SparseMatrix& vertex_edge_global,
                                     mixed_laplacians_[level - 1],
                                     std::move(gts[level - 1]), param_));
         coarsener_[level - 1]->construct_coarse_subspace(GetConstantRep(level - 1));
-        // if (level < param_.max_levels - 1)
+
+        mixed_laplacians_.push_back(coarsener_[level - 1]->GetCoarse());
+        if (level < param_.max_levels - 1 || !param_.hybridization)
         {
-            mixed_laplacians_.push_back(coarsener_[level - 1]->GetCoarse());
-            if (!param_.hybridization)
-            {
-                mixed_laplacians_.back().BuildM();
-            }
+            mixed_laplacians_.back().BuildM();
         }
     }
 

--- a/src/LocalMixedGraphSpectralTargets.cpp
+++ b/src/LocalMixedGraphSpectralTargets.cpp
@@ -247,6 +247,10 @@ MixedBlockEigensystem::MixedBlockEigensystem(
         mfem::Vector evals;
         eigs_.Compute(DMinvDt_dense, evals, evects_);
         eval_min_ = evals.Min();
+
+        // temporarily added to match dimension
+        mfem::SparseMatrix DlocT_tmp = smoothg::Transpose(Dloc_);
+        DlocT_.Swap(DlocT_tmp);
     }
 
     if (!use_w_)

--- a/src/MatrixUtilities.cpp
+++ b/src/MatrixUtilities.cpp
@@ -1082,6 +1082,7 @@ void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma
     {
         rhs_->GetBlock(1) = rhs_copy;
         solver_->Mult(*rhs_, *sol_);
+        sol_sigma = sol_->GetBlock(0);
     }
 
     // Set rhs_block1(0) back to its original vale (rhs is const BlockVector)

--- a/src/MatrixUtilities.cpp
+++ b/src/MatrixUtilities.cpp
@@ -989,6 +989,13 @@ bool IsDiag(const mfem::SparseMatrix& A)
 LocalGraphEdgeSolver::LocalGraphEdgeSolver(const mfem::SparseMatrix& M,
                                            const mfem::SparseMatrix& D,
                                            const mfem::Vector& const_rep)
+    : LocalGraphEdgeSolver(M, D)
+{
+    const_rep_.SetDataAndSize(const_rep.GetData(), const_rep.Size());
+}
+
+LocalGraphEdgeSolver::LocalGraphEdgeSolver(const mfem::SparseMatrix& M,
+                                           const mfem::SparseMatrix& D)
 {
     M_is_diag_ = IsDiag(M);
     if (M_is_diag_)
@@ -1000,16 +1007,6 @@ LocalGraphEdgeSolver::LocalGraphEdgeSolver(const mfem::SparseMatrix& M,
     {
         Init(M, D);
     }
-
-    const_rep_.SetDataAndSize(const_rep.GetData(), const_rep.Size());
-}
-
-// This constructor takes the diagonal of M (as a Vector) as input
-LocalGraphEdgeSolver::LocalGraphEdgeSolver(const mfem::Vector& M,
-                                           const mfem::SparseMatrix& D)
-{
-    M_is_diag_ = true;
-    Init(M, D);
 }
 
 void LocalGraphEdgeSolver::Init(const mfem::Vector& M_diag, const mfem::SparseMatrix& D)
@@ -1121,7 +1118,10 @@ void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs0, const mfem::Vector& rh
         sol_u *= -1.0;
     }
 
-    orthogonalize_from_vector(sol_u, const_rep_);
+    if (const_rep_.Size() > 0)
+    {
+        orthogonalize_from_vector(sol_u, const_rep_);
+    }
 }
 
 void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs1,

--- a/src/MatrixUtilities.cpp
+++ b/src/MatrixUtilities.cpp
@@ -987,7 +987,8 @@ bool IsDiag(const mfem::SparseMatrix& A)
 
 // This constructor assumes M to be diagonal
 LocalGraphEdgeSolver::LocalGraphEdgeSolver(const mfem::SparseMatrix& M,
-                                           const mfem::SparseMatrix& D)
+                                           const mfem::SparseMatrix& D,
+                                           const mfem::Vector& const_rep)
 {
     M_is_diag_ = IsDiag(M);
     if (M_is_diag_)
@@ -999,6 +1000,8 @@ LocalGraphEdgeSolver::LocalGraphEdgeSolver(const mfem::SparseMatrix& M,
     {
         Init(M, D);
     }
+
+    const_rep_.SetDataAndSize(const_rep.GetData(), const_rep.Size());
 }
 
 // This constructor takes the diagonal of M (as a Vector) as input
@@ -1088,7 +1091,7 @@ void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma
     rhs_copy(0) = rhs_0;
 }
 
-void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs0, const mfem::Vector &rhs1,
+void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs0, const mfem::Vector& rhs1,
                                 mfem::Vector& sol_sigma, mfem::Vector& sol_u) const
 {
     if (M_is_diag_)
@@ -1118,10 +1121,10 @@ void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs0, const mfem::Vector &rh
         sol_u *= -1.0;
     }
 
-    orthogonalize_from_constant(sol_u);
+    orthogonalize_from_vector(sol_u, const_rep_);
 }
 
-void LocalGraphEdgeSolver::Mult(const mfem::Vector &rhs1,
+void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs1,
                                 mfem::Vector& sol_sigma, mfem::Vector& sol_u) const
 {
     mfem::Vector rhs0(sol_sigma);

--- a/src/MatrixUtilities.cpp
+++ b/src/MatrixUtilities.cpp
@@ -985,7 +985,6 @@ bool IsDiag(const mfem::SparseMatrix& A)
     return true;
 }
 
-// This constructor assumes M to be diagonal
 LocalGraphEdgeSolver::LocalGraphEdgeSolver(const mfem::SparseMatrix& M,
                                            const mfem::SparseMatrix& D,
                                            const mfem::Vector& const_rep)
@@ -1064,52 +1063,52 @@ void LocalGraphEdgeSolver::Init(const mfem::SparseMatrix& M, const mfem::SparseM
     rhs_->GetBlock(0) = 0.0;
 }
 
-void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma) const
+void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs_u, mfem::Vector& sol_sigma) const
 {
-    // Set rhs(0)=0 so that the modified system after
+    // Set rhs_u(0) = 0 so that the modified system after
     // the elimination is consistent with the original one
-    mfem::Vector& rhs_copy = const_cast<mfem::Vector&>(rhs);
-    double rhs_0 = rhs_copy(0);
-    rhs_copy(0) = 0.;
+    mfem::Vector& rhs_u_copy = const_cast<mfem::Vector&>(rhs_u);
+    double rhs_u_0 = rhs_u_copy(0);
+    rhs_u_copy(0) = 0.;
 
     if (M_is_diag_)
     {
-        mfem::Vector sol_u_tmp(rhs.Size());
-        solver_->Mult(rhs, sol_u_tmp);
-        MinvDT_.Mult(sol_u_tmp, sol_sigma);
+        mfem::Vector sol_u(rhs_u.Size());
+        solver_->Mult(rhs_u_copy, sol_u);
+        MinvDT_.Mult(sol_u, sol_sigma);
     }
     else
     {
-        rhs_->GetBlock(1) = rhs_copy;
+        rhs_->GetBlock(1) = rhs_u_copy;
         solver_->Mult(*rhs_, *sol_);
         sol_sigma = sol_->GetBlock(0);
     }
 
-    // Set rhs_block1(0) back to its original vale (rhs is const BlockVector)
-    rhs_copy(0) = rhs_0;
+    // Set rhs_u(0) back to its original vale (rhs is const BlockVector)
+    rhs_u_copy(0) = rhs_u_0;
 }
 
-void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs0, const mfem::Vector& rhs1,
+void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs_sigma, const mfem::Vector& rhs_u,
                                 mfem::Vector& sol_sigma, mfem::Vector& sol_u) const
 {
     if (M_is_diag_)
     {
-        mfem::Vector rhs(rhs1.Size());
-        MinvDT_.MultTranspose(rhs0, rhs);
-        add(-1.0, rhs, 1.0, rhs1, rhs);
+        mfem::Vector rhs(rhs_u.Size());
+        MinvDT_.MultTranspose(rhs_sigma, rhs);
+        add(-1.0, rhs, 1.0, rhs_u, rhs);
         rhs(0) = 0.0;
 
         solver_->Mult(rhs, sol_u);
 
         MinvDT_.Mult(sol_u, sol_sigma);
-        mfem::Vector rhs0_copy(rhs0);
-        RescaleVector(Minv_, rhs0_copy);
-        sol_sigma += rhs0_copy;
+        mfem::Vector Minv_rhs_sigma(rhs_sigma);
+        RescaleVector(Minv_, Minv_rhs_sigma);
+        sol_sigma += Minv_rhs_sigma;
     }
     else
     {
-        rhs_->GetBlock(0) = rhs0;
-        rhs_->GetBlock(1) = rhs1;
+        rhs_->GetBlock(0) = rhs_sigma;
+        rhs_->GetBlock(1) = rhs_u;
         rhs_->GetBlock(1)[0] = 0.0;
 
         solver_->Mult(*rhs_, *sol_);
@@ -1125,12 +1124,12 @@ void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs0, const mfem::Vector& rh
     }
 }
 
-void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs1,
+void LocalGraphEdgeSolver::Mult(const mfem::Vector& rhs_u,
                                 mfem::Vector& sol_sigma, mfem::Vector& sol_u) const
 {
-    mfem::Vector rhs0(sol_sigma);
-    rhs0 = 0.0;
-    Mult(rhs0, rhs1, sol_sigma, sol_u);
+    mfem::Vector rhs_sigma(sol_sigma);
+    rhs_sigma = 0.0;
+    Mult(rhs_sigma, rhs_u, sol_sigma, sol_u);
 }
 
 double InnerProduct(const mfem::Vector& weight, const mfem::Vector& u,

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -343,7 +343,6 @@ public:
        @param M matrix \f$ M \f$ in the formula in the class description
        @param D matrix \f$ D \f$ in the formula in the class description
 
-       M is assumed to be diagonal (TODO: should assert?)
        We construct the matrix \f$ A = D M^{-1} D^T \f$, eliminate the zeroth
        degree of freedom to ensure it is solvable. LU factorization of \f$ A \f$
        is computed and stored (until the object is deleted) for potential

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -367,7 +367,7 @@ public:
        @brief Solves \f$ (D M^{-1} D^T) u = f - D M^{-1} g \f$,
                      \f$ \sigma = M^{-1} (D^T u + g) \f$.
 
-       @param rhs0 \f$ g \f$ in the formula above
+       @param rhs_sigma \f$ g \f$ in the formula above
        @param rhs \f$ f \f$ in the formula above
        @param sol_sigma \f$ \sigma \f$ in the formula above
        @param sol_u \f$ u \f$ in the formula above

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -353,8 +353,8 @@ public:
                          const mfem::SparseMatrix& D,
                          const mfem::Vector& const_rep);
 
-    /// M is the diagonal of the matrix \f$ M \f$ in the formula above
-    LocalGraphEdgeSolver(const mfem::Vector& M, const mfem::SparseMatrix& D);
+    /// solution u will not be orthogonalized to const_rep in solving stage
+    LocalGraphEdgeSolver(const mfem::SparseMatrix& M, const mfem::SparseMatrix& D);
 
     /**
        @brief Solves \f$ (D M^{-1} D^T) u = f\f$, \f$ \sigma = M^{-1} D^T u \f$.

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -368,7 +368,7 @@ public:
                      \f$ \sigma = M^{-1} (D^T u + g) \f$.
 
        @param rhs_sigma \f$ g \f$ in the formula above
-       @param rhs \f$ f \f$ in the formula above
+       @param rhs_u \f$ f \f$ in the formula above
        @param sol_sigma \f$ \sigma \f$ in the formula above
        @param sol_u \f$ u \f$ in the formula above
     */

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -358,10 +358,10 @@ public:
     /**
        @brief Solves \f$ (D M^{-1} D^T) u = f\f$, \f$ \sigma = M^{-1} D^T u \f$.
 
-       @param rhs \f$ f \f$ in the formula above
+       @param rhs_u \f$ f \f$ in the formula above
        @param sol_sigma \f$ \sigma \f$ in the formula above
     */
-    void Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma) const;
+    void Mult(const mfem::Vector& rhs_u, mfem::Vector& sol_sigma) const;
 
     /**
        @brief Solves \f$ (D M^{-1} D^T) u = f - D M^{-1} g \f$,
@@ -378,7 +378,7 @@ public:
     /**
        @brief Solves \f$ (D M^{-1} D^T) u = f\f$, \f$ \sigma = M^{-1} D^T u \f$.
 
-       @param rhs1 \f$ f \f$ in the formula above
+       @param rhs_u \f$ f \f$ in the formula above
        @param sol_sigma \f$ \sigma \f$ in the formula above
        @param sol_u \f$ u \f$ in the formula above
     */

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -327,7 +327,7 @@ bool IsDiag(const mfem::SparseMatrix& A);
      \end{array} \right)
      =
      \left( \begin{array}{c}
-       0 \\ -g
+       -g \\ -f
      \end{array} \right)
    \f]
 
@@ -356,26 +356,39 @@ public:
     LocalGraphEdgeSolver(const mfem::Vector& M, const mfem::SparseMatrix& D);
 
     /**
-       @brief Solves \f$ (D M^{-1} D^T) u = g\f$, \f$ \sigma = M^{-1} D^T u \f$.
+       @brief Solves \f$ (D M^{-1} D^T) u = f\f$, \f$ \sigma = M^{-1} D^T u \f$.
 
-       @param rhs \f$ g \f$ in the formula above
+       @param rhs \f$ f \f$ in the formula above
        @param sol_sigma \f$ \sigma \f$ in the formula above
     */
     void Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma) const;
 
     /**
-       @brief Solves \f$ (D M^{-1} D^T) u = g\f$, \f$ \sigma = M^{-1} D^T u \f$.
+       @brief Solves \f$ (D M^{-1} D^T) u = f - D M^{-1} g \f$,
+                     \f$ \sigma = M^{-1} (D^T u + g) \f$.
 
-       @param rhs \f$ g \f$ in the formula above
+       @param rhs0 \f$ g \f$ in the formula above
+       @param rhs \f$ f \f$ in the formula above
        @param sol_sigma \f$ \sigma \f$ in the formula above
        @param sol_u \f$ u \f$ in the formula above
     */
-    void Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma,
-              mfem::Vector& sol_u, bool do_ortho = true) const;
+    void Mult(const mfem::Vector& rhs0, const mfem::Vector& rhs1,
+              mfem::Vector& sol_sigma, mfem::Vector& sol_u) const;
+
+    /**
+       @brief Solves \f$ (D M^{-1} D^T) u = f\f$, \f$ \sigma = M^{-1} D^T u \f$.
+
+       @param rhs1 \f$ f \f$ in the formula above
+       @param sol_sigma \f$ \sigma \f$ in the formula above
+       @param sol_u \f$ u \f$ in the formula above
+    */
+    void Mult(const mfem::Vector& rhs1,
+              mfem::Vector& sol_sigma, mfem::Vector& sol_u) const;
+
 
 private:
     /// Setup matrix and solver when M is diagonal
-    void Init(const double* M_data, const mfem::SparseMatrix& D);
+    void Init(const mfem::Vector& M_diag, const mfem::SparseMatrix& D);
 
     /// Setup matrix and solver when M is not diagonal
     void Init(const mfem::SparseMatrix& M, const mfem::SparseMatrix& D);
@@ -384,6 +397,7 @@ private:
     mfem::SparseMatrix A_;
     mfem::SparseMatrix MinvDT_;
     bool M_is_diag_;
+    mfem::Vector Minv_;
     mfem::Array<int> offsets_;
     mutable std::unique_ptr<mfem::BlockVector> rhs_;
     mutable std::unique_ptr<mfem::BlockVector> sol_;

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -372,7 +372,7 @@ public:
        @param sol_sigma \f$ \sigma \f$ in the formula above
        @param sol_u \f$ u \f$ in the formula above
     */
-    void Mult(const mfem::Vector& rhs0, const mfem::Vector& rhs1,
+    void Mult(const mfem::Vector& rhs_sigma, const mfem::Vector& rhs_u,
               mfem::Vector& sol_sigma, mfem::Vector& sol_u) const;
 
     /**

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -382,7 +382,7 @@ public:
        @param sol_sigma \f$ \sigma \f$ in the formula above
        @param sol_u \f$ u \f$ in the formula above
     */
-    void Mult(const mfem::Vector& rhs1,
+    void Mult(const mfem::Vector& rhs_u,
               mfem::Vector& sol_sigma, mfem::Vector& sol_u) const;
 
 

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -350,7 +350,8 @@ public:
        multiple solves.
     */
     LocalGraphEdgeSolver(const mfem::SparseMatrix& M,
-                         const mfem::SparseMatrix& D);
+                         const mfem::SparseMatrix& D,
+                         const mfem::Vector& const_rep);
 
     /// M is the diagonal of the matrix \f$ M \f$ in the formula above
     LocalGraphEdgeSolver(const mfem::Vector& M, const mfem::SparseMatrix& D);
@@ -401,6 +402,7 @@ private:
     mfem::Array<int> offsets_;
     mutable std::unique_ptr<mfem::BlockVector> rhs_;
     mutable std::unique_ptr<mfem::BlockVector> sol_;
+    mfem::Vector const_rep_;
 };
 
 /**

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -311,6 +311,8 @@ void GenerateOffsets(MPI_Comm comm, int N, HYPRE_Int loc_sizes[],
 */
 void GenerateOffsets(MPI_Comm comm, int local_size, mfem::Array<HYPRE_Int>& offsets);
 
+bool IsDiag(const mfem::SparseMatrix& A);
+
 /**
    @brief Solver for local saddle point problems, see the formula below.
 
@@ -359,7 +361,7 @@ public:
        @param rhs \f$ g \f$ in the formula above
        @param sol_sigma \f$ \sigma \f$ in the formula above
     */
-    void Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma);
+    void Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma) const;
 
     /**
        @brief Solves \f$ (D M^{-1} D^T) u = g\f$, \f$ \sigma = M^{-1} D^T u \f$.
@@ -368,13 +370,23 @@ public:
        @param sol_sigma \f$ \sigma \f$ in the formula above
        @param sol_u \f$ u \f$ in the formula above
     */
-    void Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma, mfem::Vector& sol_u);
+    void Mult(const mfem::Vector& rhs, mfem::Vector& sol_sigma,
+              mfem::Vector& sol_u, bool do_ortho = true) const;
+
 private:
-    void Init(double* M_data, const mfem::SparseMatrix& D);
+    /// Setup matrix and solver when M is diagonal
+    void Init(const double* M_data, const mfem::SparseMatrix& D);
+
+    /// Setup matrix and solver when M is not diagonal
+    void Init(const mfem::SparseMatrix& M, const mfem::SparseMatrix& D);
 
     std::unique_ptr<mfem::UMFPackSolver> solver_;
     mfem::SparseMatrix A_;
     mfem::SparseMatrix MinvDT_;
+    bool M_is_diag_;
+    mfem::Array<int> offsets_;
+    mutable std::unique_ptr<mfem::BlockVector> rhs_;
+    mutable std::unique_ptr<mfem::BlockVector> sol_;
 };
 
 /**

--- a/src/Upscale.cpp
+++ b/src/Upscale.cpp
@@ -111,6 +111,7 @@ void Upscale::Solve(int level, const mfem::BlockVector& x, mfem::BlockVector& y)
     solver_[level]->Solve(*rhs_[level], *sol_[level]);
 
     // orthogonalize at coarse level, every level, or fine level?
+    OrthogonalizeLevel(level, sol_[level]->GetBlock(1));
 
     // interpolate solution
     for (int i = level - 1; i >= 0; --i)
@@ -118,7 +119,6 @@ void Upscale::Solve(int level, const mfem::BlockVector& x, mfem::BlockVector& y)
         coarsener_[i]->interpolate(*sol_[i + 1], *sol_[i]);
     }
     y = *sol_[0];
-    Orthogonalize(y);
 }
 
 void Upscale::Solve(const mfem::BlockVector& x, mfem::BlockVector& y) const
@@ -324,7 +324,7 @@ void Upscale::OrthogonalizeCoarse(mfem::BlockVector& vect) const
 
 void Upscale::OrthogonalizeLevel(int level, mfem::Vector& vect) const
 {
-    const mfem::Vector coarse_constant_rep = GetConstantRep(level);
+    const mfem::Vector& coarse_constant_rep = GetConstantRep(level);
     double local_dot = (vect * coarse_constant_rep);
     double global_dot;
     MPI_Allreduce(&local_dot, &global_dot, 1, MPI_DOUBLE, MPI_SUM, comm_);

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -178,6 +178,11 @@ public:
         return coarsener_[level]->get_Psigma();
     }
 
+    const mfem::SparseMatrix& GetPu(int level) const
+    {
+        return coarsener_[level]->get_Pu();
+    }
+
 protected:
     Upscale(MPI_Comm comm, int size)
         : Operator(size), comm_(comm), setup_time_(0.0)

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -173,6 +173,11 @@ public:
     /// Dump some debug data
     void DumpDebug(const std::string& prefix) const;
 
+    const mfem::SparseMatrix& GetPsigma(int level) const
+    {
+        return coarsener_[level]->get_Psigma();
+    }
+
 protected:
     Upscale(MPI_Comm comm, int size)
         : Operator(size), comm_(comm), setup_time_(0.0)

--- a/testcode/CMakeLists.txt
+++ b/testcode/CMakeLists.txt
@@ -43,6 +43,9 @@ target_link_libraries(wattsstrogatz smoothg ${TPL_LIBRARIES})
 add_executable(rescaling rescaling.cpp)
 target_link_libraries(rescaling smoothg ${TPL_LIBRARIES})
 
+add_executable(coarse_assembling coarse_assembling.cpp)
+target_link_libraries(coarse_assembling smoothg ${TPL_LIBRARIES})
+
 # add tests
 add_test(lineargraph lineargraph)
 add_test(lineargraph64 lineargraph --size 64)
@@ -77,6 +80,9 @@ add_valgrind_test(vwattsstrogatz wattsstrogatz)
 add_test(rescaling rescaling)
 add_test(parrescaling mpirun -np 2 ./rescaling)
 add_valgrind_test(vrescaling rescaling)
+
+add_test(coarse_assembling coarse_assembling -m 1)
+add_test(parcoarse_assembling mpirun -np 2 ./coarse_assembling -m 1)
 
 add_test(NAME style
   COMMAND ${ASTYLE_COMMAND} --options=smoothg.astylerc --dry-run src/*.?pp examples/*.?pp testcode/*.?pp

--- a/testcode/CMakeLists.txt
+++ b/testcode/CMakeLists.txt
@@ -81,8 +81,8 @@ add_test(rescaling rescaling)
 add_test(parrescaling mpirun -np 2 ./rescaling)
 add_valgrind_test(vrescaling rescaling)
 
-add_test(coarse_assembling coarse_assembling -m 1)
-add_test(parcoarse_assembling mpirun -np 2 ./coarse_assembling -m 1)
+add_test(coarse_assembling coarse_assembling -m 1 --perm ${SPE10_PERM})
+add_test(parcoarse_assembling mpirun -np 2 ./coarse_assembling -m 1 --perm ${SPE10_PERM})
 
 add_test(NAME style
   COMMAND ${ASTYLE_COMMAND} --options=smoothg.astylerc --dry-run src/*.?pp examples/*.?pp testcode/*.?pp

--- a/testcode/coarse_assembling.cpp
+++ b/testcode/coarse_assembling.cpp
@@ -1,0 +1,167 @@
+/*BHEADER**********************************************************************
+ *
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * LLNL-CODE-745247. All Rights reserved. See file COPYRIGHT for details.
+ *
+ * This file is part of smoothG. For more information and source code
+ * availability, see https://www.github.com/llnl/smoothG.
+ *
+ * smoothG is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ ***********************************************************************EHEADER*/
+
+/**
+   @file finitevolume.cpp
+   @brief This is an example for upscaling a graph Laplacian coming from a finite
+   volume discretization of a simple reservior model in parallel.
+
+   A simple way to run the example:
+
+   mpirun -n 4 ./finitevolume
+*/
+
+#include <fstream>
+#include <sstream>
+#include <mpi.h>
+
+#include "mfem.hpp"
+#include "../examples/spe10.hpp"
+
+#include "../src/picojson.h"
+#include "../src/smoothG.hpp"
+
+using namespace smoothg;
+
+int main(int argc, char* argv[])
+{
+    int num_procs, myid;
+    picojson::object serialize;
+
+    // 1. Initialize MPI
+    mpi_session session(argc, argv);
+    MPI_Comm comm = MPI_COMM_WORLD;
+    MPI_Comm_size(comm, &num_procs);
+    MPI_Comm_rank(comm, &myid);
+
+    // program options from command line
+    UpscaleParameters upscale_param;
+    mfem::OptionsParser args(argc, argv);
+    const char* permFile = "spe_perm.dat";
+    args.AddOption(&permFile, "-p", "--perm",
+                   "SPE10 permeability file data.");
+    int nDimensions = 2;
+    args.AddOption(&nDimensions, "-d", "--dim",
+                   "Dimension of the physical space.");
+    int slice = 0;
+    args.AddOption(&slice, "-s", "--slice",
+                   "Slice of SPE10 data to take for 2D run.");
+
+    upscale_param.max_levels = 3;
+    upscale_param.hybridization = true;
+
+    // Read upscaling options from command line into upscale_param object
+    upscale_param.RegisterInOptionsParser(args);
+    args.Parse();
+    if (!args.Good())
+    {
+        if (myid == 0)
+        {
+            args.PrintUsage(std::cout);
+        }
+        MPI_Finalize();
+        return 1;
+    }
+    if (myid == 0)
+    {
+        args.PrintOptions(std::cout);
+    }
+
+    const int nbdr = nDimensions == 3 ? 6 : 4;
+    mfem::Array<int> ess_attr(nbdr);
+    ess_attr = 0;
+
+    const bool metis_agglomeration = false;
+    const double proc_part_ubal = 2.0;
+    const int spe10_scale = 5;
+    mfem::Array<int> coarseningFactor(3);
+
+    // Setting up finite volume discretization problem
+    SPE10Problem spe10problem(permFile, nDimensions, spe10_scale, slice,
+                              metis_agglomeration, proc_part_ubal, coarseningFactor);
+
+    mfem::ParMesh* pmesh = spe10problem.GetParMesh();
+
+    if (myid == 0)
+    {
+        std::cout << pmesh->GetNEdges() << " fine edges, " <<
+                  pmesh->GetNFaces() << " fine faces, " <<
+                  pmesh->GetNE() << " fine elements\n";
+    }
+
+    // Construct "finite volume mass" matrix using mfem instead of parelag
+    mfem::Vector weight;
+
+    mfem::RT_FECollection sigmafec(0, nDimensions);
+    mfem::ParFiniteElementSpace sigmafespace(pmesh, &sigmafec);
+
+    mfem::ParBilinearForm a(&sigmafespace);
+    a.AddDomainIntegrator(
+        new FiniteVolumeMassIntegrator(*spe10problem.GetKInv()) );
+    a.Assemble();
+    a.Finalize();
+    a.SpMat().GetDiag(weight);
+
+    for (int i = 0; i < weight.Size(); ++i)
+    {
+        weight[i] = 1.0 / weight[i];
+    }
+
+    // Construct vertex_edge table in mfem::SparseMatrix format
+    auto& vertex_edge_table = nDimensions == 2 ? pmesh->ElementToEdgeTable()
+                              : pmesh->ElementToFaceTable();
+    const mfem::SparseMatrix vertex_edge = TableToMatrix(vertex_edge_table);
+
+    // Construct agglomerated topology based on METIS or Cartesian agglomeration
+    mfem::Array<int> partitioning;
+    PartitionAAT(vertex_edge, partitioning, upscale_param.coarse_factor);
+
+    const auto& edge_d_td(sigmafespace.Dof_TrueDof_Matrix());
+
+    auto edge_boundary_att = GenerateBoundaryAttributeTable(pmesh);
+
+    // Create Upscaler and Solve
+    FiniteVolumeUpscale fvupscale(comm, vertex_edge, weight, partitioning, *edge_d_td,
+                                  edge_boundary_att, ess_attr, upscale_param);
+
+    fvupscale.PrintInfo();
+    fvupscale.ShowSetupTime();
+
+    for (int level = 1; level < upscale_param.max_levels; ++level)
+    {
+        fvupscale.GetMatrix(level - 1).BuildM();
+        const mfem::SparseMatrix& Mfine(fvupscale.GetMatrix(level - 1).GetM());
+        mfem::SparseMatrix PsigmaT = smoothg::Transpose(fvupscale.GetPsigma(level - 1));
+        unique_ptr<mfem::SparseMatrix> Mcoarse_RAP( mfem::RAP(Mfine, PsigmaT) );
+
+        fvupscale.GetMatrix(level).BuildM();
+        const mfem::SparseMatrix& Mcoarse_smoothG = fvupscale.GetMatrix(level).GetM();
+
+        Mcoarse_RAP->Add(-1.0, Mcoarse_smoothG);
+        const double diff_maxnorm = Mcoarse_RAP->MaxNorm();
+        if (diff_maxnorm > 1e-8)
+        {
+            if (myid == 0)
+            {
+                std::cout << "Level " << level << ": || M_smoothG - M_RAP ||_inf = "
+                          << diff_maxnorm << "\n";
+            }
+
+            return EXIT_FAILURE;
+        }
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/testcode/coarse_assembling.cpp
+++ b/testcode/coarse_assembling.cpp
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
         const mfem::SparseMatrix& Dfine(fvupscale.GetMatrix(level - 1).GetD());
         const mfem::SparseMatrix& Psigma = fvupscale.GetPsigma(level - 1);
         unique_ptr<mfem::SparseMatrix> Dcoarse_RAP(
-                    mfem::RAP(fvupscale.GetPu(level - 1), Dfine, Psigma) );
+            mfem::RAP(fvupscale.GetPu(level - 1), Dfine, Psigma) );
 
         const mfem::SparseMatrix& Dcoarse_smoothG = fvupscale.GetMatrix(level).GetD();
 

--- a/testcode/coarse_assembling.cpp
+++ b/testcode/coarse_assembling.cpp
@@ -150,7 +150,10 @@ int main(int argc, char* argv[])
         const mfem::SparseMatrix& Mcoarse_smoothG = fvupscale.GetMatrix(level).GetM();
 
         Mcoarse_RAP->Add(-1.0, Mcoarse_smoothG);
-        const double diff_maxnorm = Mcoarse_RAP->MaxNorm();
+        double diff_maxnorm_loc = Mcoarse_RAP->MaxNorm();
+        double diff_maxnorm;
+        MPI_Allreduce(&diff_maxnorm_loc, &diff_maxnorm, 1, MPI_DOUBLE, MPI_MAX, comm);
+
         if (diff_maxnorm > 1e-8)
         {
             if (myid == 0)

--- a/testcode/coarse_assembling.cpp
+++ b/testcode/coarse_assembling.cpp
@@ -14,13 +14,9 @@
  ***********************************************************************EHEADER*/
 
 /**
-   @file finitevolume.cpp
-   @brief This is an example for upscaling a graph Laplacian coming from a finite
-   volume discretization of a simple reservior model in parallel.
-
-   A simple way to run the example:
-
-   mpirun -n 4 ./finitevolume
+   @file coarse_assembling.cpp
+   @brief Test if the coarse M and D constructed in GraphCoarsen coincide
+   with the RAP approach.
 */
 
 #include <fstream>

--- a/testcode/lineargraphthree.cpp
+++ b/testcode/lineargraphthree.cpp
@@ -128,7 +128,6 @@ int main(int argc, char* argv[])
         fine_rhs.GetBlock(1)[i] = -1.0;
     }
 
-
     mfem::BlockVector sol0(fine_rhs);
     upscale.Solve(0, fine_rhs, sol0);
     upscale.ShowSolveInfo(0);
@@ -141,17 +140,6 @@ int main(int argc, char* argv[])
     upscale.Solve(2, fine_rhs, sol2);
     upscale.ShowSolveInfo(2);
 
-
-
-    mfem::SparseMatrix Mfine(upscale.GetMatrix(1).GetM());
-    mfem::SparseMatrix PsigmaT = smoothg::Transpose(upscale.GetPsigma(1));
-    mfem::SparseMatrix* Mcoarse = mfem::RAP(Mfine, PsigmaT);
-    Mcoarse->Print();
-
-    std::cout<<"\n\n";
-    upscale.GetMatrix(2).GetM().Print();
-
-//    if (false)
     {
         for (int i = 0; i < sol0.GetBlock(1).Size(); ++i)
         {


### PR DESCRIPTION
This PR is another step towards multilevel coarsening. Two main changes are:

1. `LocalGraphEdgeSolver` no longer assumes diagonal M, and the orthogonalization is also performed against user-provided representation of "constant", not hard-coded constant 1.

2. In `GraphCoarsen`, assembling of coarse (element) M and D is modified to accommodate non-diagonal finer-level M.

After these modifications, multilevel coarsening with "max_evects = 1" seems to work.

For example, the solution of `lineargraphthree` now looks reasonable:
```
./lineargraphthree --size 64 --partitions 32 --coarse-factor 2
```

I also tested the `finitevolume` and `generalgraph` examples with 3 or more levels, and seems getting reasonable approximation (need to set `-m  1` in command line). 

If this is merged, I think next step is generalization to higher order coarsening, which requires appropriate aggregation of dofs. 