### PR TITLE
GraphTopology refactoring

### DIFF
--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -41,12 +41,8 @@ Graph::Graph(MPI_Comm comm,
 Graph::Graph(const mfem::SparseMatrix& vertex_edge_local,
              const mfem::HypreParMatrix& edge_trueedge,
              const mfem::Vector& edge_weight_local)
-    : vertex_edge_local_(vertex_edge_local)
+    : vertex_edge_local_(vertex_edge_local), edge_trueedge_(Copy(edge_trueedge))
 {
-    // temporary work-around (TODO: make a copy function for HypreParMatrix)
-    unique_ptr<mfem::HypreParMatrix> trueedge_edge(edge_trueedge.Transpose());
-    edge_trueedge_.reset(trueedge_edge->Transpose());
-
     if (edge_weight_local.Size() > 0)
     {
         SplitEdgeWeight(edge_weight_local);
@@ -63,20 +59,15 @@ Graph::Graph(const mfem::SparseMatrix& vertex_edge_local,
 Graph::Graph(const mfem::SparseMatrix& vertex_edge_local,
              const mfem::HypreParMatrix& edge_trueedge,
              const std::vector<mfem::Vector>& split_edge_weight)
-    : vertex_edge_local_(vertex_edge_local), split_edge_weight_(split_edge_weight)
-{
-    // temporary work-around (TODO: make a copy function for HypreParMatrix)
-    unique_ptr<mfem::HypreParMatrix> trueedge_edge(edge_trueedge.Transpose());
-    edge_trueedge_.reset(trueedge_edge->Transpose());
-}
+    : vertex_edge_local_(vertex_edge_local), edge_trueedge_(Copy(edge_trueedge)),
+      split_edge_weight_(split_edge_weight)
+{ }
 
 Graph::Graph(const Graph& other) noexcept
     : vertex_edge_local_(other.vertex_edge_local_),
+      edge_trueedge_(Copy(*other.edge_trueedge_)),
       split_edge_weight_(other.split_edge_weight_)
 {
-    unique_ptr<mfem::HypreParMatrix> trueedge_edge(other.edge_trueedge_->Transpose());
-    edge_trueedge_.reset(trueedge_edge->Transpose());
-
     other.vert_loc_to_glo_.Copy(vert_loc_to_glo_);
     other.edge_loc_to_glo_.Copy(edge_loc_to_glo_);
     other.vertex_starts_.Copy(vertex_starts_);

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -70,6 +70,18 @@ Graph::Graph(const mfem::SparseMatrix& vertex_edge_local,
     edge_trueedge_.reset(trueedge_edge->Transpose());
 }
 
+Graph::Graph(const Graph& other) noexcept
+    : vertex_edge_local_(other.vertex_edge_local_),
+      split_edge_weight_(other.split_edge_weight_)
+{
+    unique_ptr<mfem::HypreParMatrix> trueedge_edge(other.edge_trueedge_->Transpose());
+    edge_trueedge_.reset(trueedge_edge->Transpose());
+
+    other.vert_loc_to_glo_.Copy(vert_loc_to_glo_);
+    other.edge_loc_to_glo_.Copy(edge_loc_to_glo_);
+    other.vertex_starts_.Copy(vertex_starts_);
+}
+
 Graph::Graph(Graph&& other) noexcept
 {
     swap(*this, other);

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -100,6 +100,9 @@ public:
     /// Default constructor
     Graph() = default;
 
+    /// Copy constructor
+    Graph(const Graph& other) noexcept;
+
     /// Move constructor
     Graph(Graph&& other) noexcept;
 

--- a/src/GraphTopology.cpp
+++ b/src/GraphTopology.cpp
@@ -96,7 +96,6 @@ GraphTopology::GraphTopology(GraphTopology&& graph_topology) noexcept
     Swap(face_start_, graph_topology.GetFaceStart());
 
     std::swap(fine_graph_, graph_topology.fine_graph_);
-    std::swap(coarse_graph_, graph_topology.coarse_graph_);
 
     edge_boundaryattr_ = graph_topology.edge_boundaryattr_;
     edge_trueedge_edge_ = graph_topology.edge_trueedge_edge_;
@@ -360,9 +359,7 @@ Graph GraphTopology::Coarsen(const mfem::Array<int>& partitioning)
     // Construct "face to true face" table
     face_trueface_ = BuildEntityToTrueEntity(*face_trueface_face_);
 
-    Graph coarse_graph(Agg_face_, *face_trueface_);
-    coarse_graph_ = &coarse_graph;
-    return coarse_graph;
+    return Graph(Agg_face_, *face_trueface_);
 }
 
 std::vector<GraphTopology> MultilevelGraphTopology(

--- a/src/GraphTopology.cpp
+++ b/src/GraphTopology.cpp
@@ -97,6 +97,9 @@ GraphTopology::GraphTopology(GraphTopology&& graph_topology) noexcept
 
     std::swap(fine_graph_, graph_topology.fine_graph_);
     std::swap(coarse_graph_, graph_topology.coarse_graph_);
+
+    edge_boundaryattr_ = graph_topology.edge_boundaryattr_;
+    edge_trueedge_edge_ = graph_topology.edge_trueedge_edge_;
 }
 
 

--- a/src/GraphTopology.hpp
+++ b/src/GraphTopology.hpp
@@ -80,8 +80,6 @@ public:
 
     const Graph& FineGraph() const { return *fine_graph_; }
 
-    const Graph& CoarseGraph() const { return *coarse_graph_; }
-
     /// Return number of faces in aggregated graph
     unsigned int NumFaces() const { return Agg_face_.Width(); }
     /// Return number of aggregates in coarse graph
@@ -124,7 +122,6 @@ public:
 private:
 
     const Graph* fine_graph_;
-    const Graph* coarse_graph_;
 
     const mfem::SparseMatrix* edge_boundaryattr_;
     const mfem::HypreParMatrix* edge_trueedge_edge_;

--- a/src/LocalMixedGraphSpectralTargets.cpp
+++ b/src/LocalMixedGraphSpectralTargets.cpp
@@ -488,7 +488,7 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
     // Compute face to permuted edge relation table
     auto& face_start = const_cast<mfem::Array<HYPRE_Int>&>(graph_topology_.GetFaceStart());
     auto& edge_trueedge = const_cast<mfem::HypreParMatrix&>(
-                graph_topology_.FineGraph().GetEdgeToTrueEdge());
+                              graph_topology_.FineGraph().GetEdgeToTrueEdge());
 
     auto& face_edge = const_cast<mfem::SparseMatrix&>(graph_topology_.face_edge_);
     mfem::HypreParMatrix face_edge_d(comm_, face_start.Last(), edge_trueedge.M(),

--- a/src/LocalMixedGraphSpectralTargets.cpp
+++ b/src/LocalMixedGraphSpectralTargets.cpp
@@ -75,7 +75,7 @@ LocalMixedGraphSpectralTargets::LocalMixedGraphSpectralTargets(
     const mfem::SparseMatrix& M_local, const mfem::SparseMatrix& D_local,
     const mfem::SparseMatrix* W_local, const GraphTopology& graph_topology)
     :
-    comm_(graph_topology.edge_trueedge_.GetComm()),
+    comm_(graph_topology.FineGraph().GetComm()),
     rel_tol_(rel_tol),
     max_evects_(max_evects),
     dual_target_(dual_target),
@@ -98,7 +98,7 @@ LocalMixedGraphSpectralTargets::LocalMixedGraphSpectralTargets(
 
     mfem::HypreParMatrix M_d(comm_, edgedof_starts.Last(), edgedof_starts, M_local_ptr);
 
-    const mfem::HypreParMatrix& edge_trueedge(graph_topology.edge_trueedge_);
+    const mfem::HypreParMatrix& edge_trueedge(graph_topology.FineGraph().GetEdgeToTrueEdge());
     M_global_.reset(smoothg::RAP(M_d, edge_trueedge));
 
     mfem::HypreParMatrix D_d(comm_, vertdof_starts.Last(), edgedof_starts.Last(),
@@ -126,10 +126,10 @@ LocalMixedGraphSpectralTargets::LocalMixedGraphSpectralTargets(
 void LocalMixedGraphSpectralTargets::BuildExtendedAggregates()
 {
     mfem::HypreParMatrix edge_trueedge;
-    edge_trueedge.MakeRef(graph_topology_.edge_trueedge_);
+    edge_trueedge.MakeRef(graph_topology_.FineGraph().GetEdgeToTrueEdge());
 
     // hypre may modify the matrix, so make a deep copy
-    mfem::SparseMatrix vertex_edge(graph_topology_.vertex_edge_);
+    mfem::SparseMatrix vertex_edge(graph_topology_.FineGraph().GetVertexToEdge());
 
     // Construct extended aggregate to vertex dofs relation tables
     mfem::HypreParMatrix vertex_edge_bd(comm_, vertdof_starts.Last(), edgedof_starts.Last(),
@@ -487,7 +487,8 @@ void LocalMixedGraphSpectralTargets::ComputeVertexTargets(
 
     // Compute face to permuted edge relation table
     auto& face_start = const_cast<mfem::Array<HYPRE_Int>&>(graph_topology_.GetFaceStart());
-    auto& edge_trueedge = const_cast<mfem::HypreParMatrix&>(graph_topology_.edge_trueedge_);
+    auto& edge_trueedge = const_cast<mfem::HypreParMatrix&>(
+                graph_topology_.FineGraph().GetEdgeToTrueEdge());
 
     auto& face_edge = const_cast<mfem::SparseMatrix&>(graph_topology_.face_edge_);
     mfem::HypreParMatrix face_edge_d(comm_, face_start.Last(), edge_trueedge.M(),

--- a/src/MatrixUtilities.cpp
+++ b/src/MatrixUtilities.cpp
@@ -1244,5 +1244,11 @@ void BooleanMult(const mfem::SparseMatrix& mat, const mfem::Array<int>& vec,
     }
 }
 
+unique_ptr<mfem::HypreParMatrix> Copy(const mfem::HypreParMatrix& mat)
+{
+    // temporary work-around suggested by Veselin
+    // TODO: make a direct copy function for HypreParMatrix
+    return unique_ptr<mfem::HypreParMatrix>(mfem::Add(1.0, mat, 0.0, mat));
+}
 
 } // namespace smoothg

--- a/src/MatrixUtilities.hpp
+++ b/src/MatrixUtilities.hpp
@@ -450,6 +450,12 @@ std::unique_ptr<mfem::HypreParMatrix> BuildEntityToTrueEntity(
 */
 void BooleanMult(const mfem::SparseMatrix& mat, const mfem::Array<int>& vec,
                  mfem::Array<int>& out);
+
+/**
+   @brief Make a copy of mfem::HypreParMatrix
+*/
+std::unique_ptr<mfem::HypreParMatrix> Copy(const mfem::HypreParMatrix& mat);
+
 } // namespace smoothg
 
 #endif /* __MATRIXUTILITIES_HPP__ */

--- a/src/MixedMatrix.cpp
+++ b/src/MixedMatrix.cpp
@@ -39,7 +39,7 @@ MixedMatrix::MixedMatrix(const Graph& graph, const mfem::SparseMatrix& w_block,
     Init(graph.GetVertexToEdge(), graph.GetEdgeWeight(), w_block);
 }
 
-MixedMatrix::MixedMatrix(const Graph &graph, std::unique_ptr<MBuilder> mbuilder,
+MixedMatrix::MixedMatrix(const Graph& graph, std::unique_ptr<MBuilder> mbuilder,
                          std::unique_ptr<mfem::SparseMatrix> D,
                          std::unique_ptr<mfem::SparseMatrix> W,
                          const mfem::HypreParMatrix& edge_d_td,

--- a/src/MixedMatrix.cpp
+++ b/src/MixedMatrix.cpp
@@ -31,19 +31,22 @@ using std::unique_ptr;
 namespace smoothg
 {
 
-MixedMatrix::MixedMatrix(const Graph& graph, const mfem::SparseMatrix& w_block)
-    : edge_d_td_(&graph.GetEdgeToTrueEdge()),
-      edge_td_d_(edge_d_td_->Transpose())
+MixedMatrix::MixedMatrix(const Graph& graph, const mfem::SparseMatrix& w_block,
+                         const mfem::SparseMatrix* edge_bdratt)
+    : edge_d_td_(&graph.GetEdgeToTrueEdge()), edge_td_d_(edge_d_td_->Transpose()),
+      graph_(&graph), edge_bdratt_(edge_bdratt)
 {
     Init(graph.GetVertexToEdge(), graph.GetEdgeWeight(), w_block);
 }
 
-MixedMatrix::MixedMatrix(std::unique_ptr<MBuilder> mbuilder,
+MixedMatrix::MixedMatrix(const Graph &graph, std::unique_ptr<MBuilder> mbuilder,
                          std::unique_ptr<mfem::SparseMatrix> D,
                          std::unique_ptr<mfem::SparseMatrix> W,
-                         const mfem::HypreParMatrix& edge_d_td)
+                         const mfem::HypreParMatrix& edge_d_td,
+                         const mfem::SparseMatrix* edge_bdratt)
     : D_(std::move(D)), W_(std::move(W)), edge_d_td_(&edge_d_td),
-      edge_td_d_(edge_d_td.Transpose()), mbuilder_(std::move(mbuilder))
+      edge_td_d_(edge_d_td.Transpose()), mbuilder_(std::move(mbuilder)),
+      graph_(&graph), edge_bdratt_(edge_bdratt)
 {
     GenerateRowStarts();
 }

--- a/src/MixedMatrix.hpp
+++ b/src/MixedMatrix.hpp
@@ -55,7 +55,8 @@ public:
        @param w_block the matrix W. If not provided, it is assumed to be zero
     */
     MixedMatrix(const Graph& graph,
-                const mfem::SparseMatrix& w_block = SparseIdentity(0));
+                const mfem::SparseMatrix& w_block = SparseIdentity(0),
+                const mfem::SparseMatrix* edge_bdratt = nullptr);
 
     /**
        @brief Construct a mixed system directly from building blocks.
@@ -65,10 +66,16 @@ public:
        @param W the matrix W. If it is nullptr, it is assumed to be zero
        @param edge_d_td edge dof to true edge dof table
     */
-    MixedMatrix(std::unique_ptr<MBuilder> mbuilder,
+    MixedMatrix(const Graph& graph,
+                std::unique_ptr<MBuilder> mbuilder,
                 std::unique_ptr<mfem::SparseMatrix> D,
                 std::unique_ptr<mfem::SparseMatrix> W,
-                const mfem::HypreParMatrix& edge_d_td);
+                const mfem::HypreParMatrix& edge_d_td,
+                const mfem::SparseMatrix* edge_bdratt);
+
+    const Graph& GetGraph() const { return *graph_; }
+
+    const mfem::SparseMatrix* GetEdgeBdrAtt() const { return edge_bdratt_; }
 
     /**
        @brief Get a const reference to the mass matrix M.
@@ -345,6 +352,9 @@ private:
     mutable std::unique_ptr<mfem::Array<int>> blockTrueOffsets_;
 
     std::unique_ptr<MBuilder> mbuilder_;
+
+    const Graph* graph_;
+    const mfem::SparseMatrix* edge_bdratt_;
 }; // class MixedMatrix
 
 } // namespace smoothg

--- a/src/Mixed_GL_Coarsener.cpp
+++ b/src/Mixed_GL_Coarsener.cpp
@@ -96,7 +96,8 @@ const mfem::SparseMatrix& Mixed_GL_Coarsener::construct_face_facedof_table() con
 
 MixedMatrix Mixed_GL_Coarsener::GetCoarse()
 {
-    return MixedMatrix(GetCoarseMBuilder(), GetCoarseD(), GetCoarseW(), get_face_dof_truedof_table());
+    return MixedMatrix(coarse_graph_, GetCoarseMBuilder(), GetCoarseD(), GetCoarseW(),
+                       get_face_dof_truedof_table(), graph_topology_.face_bdratt_.get());
 }
 
 const mfem::HypreParMatrix& Mixed_GL_Coarsener::get_face_dof_truedof_table() const

--- a/src/Mixed_GL_Coarsener.cpp
+++ b/src/Mixed_GL_Coarsener.cpp
@@ -19,57 +19,45 @@
    @brief Implements Mixed_GL_Coarsener
 */
 
-#ifndef __MIXED_GL_COARSENER_IMPL_HPP__
-#define __MIXED_GL_COARSENER_IMPL_HPP__
-
 #include "Mixed_GL_Coarsener.hpp"
 #include <assert.h>
 
 namespace smoothg
 {
 
-const mfem::SparseMatrix& Mixed_GL_Coarsener::get_Pu() const
+const mfem::SparseMatrix& Mixed_GL_Coarsener::GetPu() const
 {
     check_subspace_construction_("Pu");
     return Pu_;
 }
 
-const mfem::SparseMatrix& Mixed_GL_Coarsener::get_Psigma() const
+const mfem::SparseMatrix& Mixed_GL_Coarsener::GetPsigma() const
 {
     check_subspace_construction_("Psigma");
     return Psigma_;
 }
 
-std::unique_ptr<mfem::BlockVector> Mixed_GL_Coarsener::restrict_rhs(
-    const mfem::BlockVector& rhs) const
-{
-    auto coarse_rhs = make_unique<mfem::BlockVector>(get_blockoffsets());
-    restrict(rhs, *coarse_rhs);
-
-    return coarse_rhs;
-}
-
-void Mixed_GL_Coarsener::restrict(const mfem::BlockVector& fine_vect,
+void Mixed_GL_Coarsener::Restrict(const mfem::BlockVector& fine_vect,
                                   mfem::BlockVector& coarse_vect) const
 {
     Psigma_.MultTranspose(fine_vect.GetBlock(0), coarse_vect.GetBlock(0));
     Pu_.MultTranspose(fine_vect.GetBlock(1), coarse_vect.GetBlock(1));
 }
 
-void Mixed_GL_Coarsener::interpolate(const mfem::BlockVector& coarse_vect,
+void Mixed_GL_Coarsener::Interpolate(const mfem::BlockVector& coarse_vect,
                                      mfem::BlockVector& fine_vect) const
 {
     Psigma_.Mult(coarse_vect.GetBlock(0), fine_vect.GetBlock(0));
     Pu_.Mult(coarse_vect.GetBlock(1), fine_vect.GetBlock(1));
 }
 
-void Mixed_GL_Coarsener::restrict(const mfem::Vector& fine_vect,
+void Mixed_GL_Coarsener::Restrict(const mfem::Vector& fine_vect,
                                   mfem::Vector& coarse_vect) const
 {
     Pu_.MultTranspose(fine_vect, coarse_vect);
 }
 
-void Mixed_GL_Coarsener::interpolate(const mfem::Vector& coarse_vect,
+void Mixed_GL_Coarsener::Interpolate(const mfem::Vector& coarse_vect,
                                      mfem::Vector& fine_vect) const
 {
     Pu_.Mult(coarse_vect, fine_vect);
@@ -80,12 +68,6 @@ const mfem::SparseMatrix& Mixed_GL_Coarsener::construct_Agg_cvertexdof_table() c
 {
     check_subspace_construction_("Agg_cvertexdof_table");
     return graph_coarsen_->GetAggToCoarseVertexDof();
-}
-
-const mfem::SparseMatrix& Mixed_GL_Coarsener::construct_Agg_cedgedof_table() const
-{
-    check_subspace_construction_("Agg_cedgedof_table");
-    return graph_coarsen_->GetAggToCoarseEdgeDof();
 }
 
 const mfem::SparseMatrix& Mixed_GL_Coarsener::construct_face_facedof_table() const
@@ -106,7 +88,7 @@ const mfem::HypreParMatrix& Mixed_GL_Coarsener::get_face_dof_truedof_table() con
     if (!face_dof_truedof_table_)
     {
         face_dof_truedof_table_ = graph_coarsen_->BuildEdgeCoarseDofTruedof(
-                                      face_facedof_table_, get_Psigma());
+                                      face_facedof_table_, GetPsigma());
         face_dof_truedof_table_->CopyRowStarts();
         face_dof_truedof_table_->CopyColStarts();
     }
@@ -115,20 +97,5 @@ const mfem::HypreParMatrix& Mixed_GL_Coarsener::get_face_dof_truedof_table() con
     return *face_dof_truedof_table_;
 }
 
-mfem::Array<int>& Mixed_GL_Coarsener::get_blockoffsets() const
-{
-    assert(face_dof_truedof_table_);
-
-    if (!coarseBlockOffsets_)
-    {
-        coarseBlockOffsets_ = make_unique<mfem::Array<int>>(3);
-        (*coarseBlockOffsets_)[0] = 0;
-        (*coarseBlockOffsets_)[1] = face_dof_truedof_table_->GetNumRows();
-        (*coarseBlockOffsets_)[2] = (*coarseBlockOffsets_)[1] + Pu_.Width();
-    }
-    return *coarseBlockOffsets_;
-}
-
 } // namespace smoothg
 
-#endif /* __MIXED_GL_COARSENER_IMPL_HPP__ */

--- a/src/Mixed_GL_Coarsener.hpp
+++ b/src/Mixed_GL_Coarsener.hpp
@@ -67,55 +67,21 @@ public:
         is_coarse_subspace_constructed_ = true;
     }
 
-    const mfem::SparseMatrix& get_Psigma() const;
-    const mfem::SparseMatrix& get_Pu() const;
-    const std::vector<mfem::DenseMatrix>& get_CM_el() const;
-
-    /// Restrict (coarsen) the (block) right-hand side by multiplying by \f$ P_\sigma, P_u \f$
-    std::unique_ptr<mfem::BlockVector> restrict_rhs(
-        const mfem::BlockVector& rhs) const;
+    const mfem::SparseMatrix& GetPsigma() const;
+    const mfem::SparseMatrix& GetPu() const;
 
     // Mixed form
-    void restrict(const mfem::BlockVector& rhs, mfem::BlockVector& coarse_rhs) const;
-    void interpolate(const mfem::BlockVector& rhs, mfem::BlockVector& fine_rhs) const;
+    void Restrict(const mfem::BlockVector& rhs, mfem::BlockVector& coarse_rhs) const;
+    void Interpolate(const mfem::BlockVector& rhs, mfem::BlockVector& fine_rhs) const;
 
     // Primal form
-    void restrict(const mfem::Vector& rhs, mfem::Vector& coarse_rhs) const;
-    void interpolate(const mfem::Vector& rhs, mfem::Vector& fine_rhs) const;
+    void Restrict(const mfem::Vector& rhs, mfem::Vector& coarse_rhs) const;
+    void Interpolate(const mfem::Vector& rhs, mfem::Vector& fine_rhs) const;
 
     const mfem::SparseMatrix& construct_Agg_cvertexdof_table() const;
-    const mfem::SparseMatrix& construct_Agg_cedgedof_table() const;
     const mfem::SparseMatrix& construct_face_facedof_table() const;
 
     const mfem::HypreParMatrix& get_face_dof_truedof_table() const;
-
-    /**
-        @brief Get the Array of offsets representing the block structure of
-        the coarse matrix.
-
-        The Array is of length 3. The first element is the starting
-        index of the first block (always 0), the second element is the
-        starting index of the second block, and the third element is
-        the total number of rows in the matrix.
-    */
-    mfem::Array<int>& get_blockoffsets() const;
-
-    unsigned int get_num_faces()
-    {
-        return graph_topology_.NumFaces();
-    }
-    unsigned int get_num_aggregates()
-    {
-        return graph_topology_.NumAggs();
-    }
-    const GraphTopology& get_GraphTopology_ref() const
-    {
-        return graph_topology_;
-    }
-    const GraphCoarsen& get_GraphCoarsen_ref() const
-    {
-        return *graph_coarsen_;
-    }
 
     /**
        @brief Get the coarse M matrix
@@ -130,7 +96,7 @@ public:
     */
     std::unique_ptr<mfem::SparseMatrix> GetCoarseD()
     {
-        return std::move(CoarseD_);
+        return std::move(coarse_D_);
     }
 
     /**
@@ -138,7 +104,7 @@ public:
     */
     std::unique_ptr<mfem::SparseMatrix> GetCoarseW()
     {
-        return std::move(CoarseW_);
+        return std::move(coarse_W_);
     }
 
     /**
@@ -168,17 +134,16 @@ protected:
     mfem::SparseMatrix Psigma_;
     mfem::SparseMatrix Pu_;
 
-    mutable std::unique_ptr<mfem::Array<int>> coarseBlockOffsets_;
     mutable std::unique_ptr<mfem::HypreParMatrix> face_dof_truedof_table_;
 
     /// Builder for coarse M operator
     std::unique_ptr<CoarseMBuilder> coarse_m_builder_;
 
     /// Coarse D operator
-    std::unique_ptr<mfem::SparseMatrix> CoarseD_;
+    std::unique_ptr<mfem::SparseMatrix> coarse_D_;
 
     /// Coarse W operator
-    std::unique_ptr<mfem::SparseMatrix> CoarseW_;
+    std::unique_ptr<mfem::SparseMatrix> coarse_W_;
 
     Graph coarse_graph_;
 }; // class Mixed_GL_Coarsener

--- a/src/Mixed_GL_Coarsener.hpp
+++ b/src/Mixed_GL_Coarsener.hpp
@@ -43,9 +43,8 @@ public:
        @brief Build a coarsener from the graph Laplacian and the
        agglomerated topology.
     */
-    Mixed_GL_Coarsener(const MixedMatrix& mgL,
-                       GraphTopology gt)
-        : mgL_(mgL), graph_topology_(std::move(gt)) {}
+    Mixed_GL_Coarsener(const MixedMatrix& mgL)
+        : mgL_(mgL), graph_topology_(mgL.GetGraph(), mgL.GetEdgeBdrAtt()) {}
 
     virtual ~Mixed_GL_Coarsener() {}
 
@@ -180,6 +179,8 @@ protected:
 
     /// Coarse W operator
     std::unique_ptr<mfem::SparseMatrix> CoarseW_;
+
+    Graph coarse_graph_;
 }; // class Mixed_GL_Coarsener
 
 } // namespace smoothg

--- a/src/SpectralAMG_MGL_Coarsener.cpp
+++ b/src/SpectralAMG_MGL_Coarsener.cpp
@@ -71,8 +71,8 @@ void SpectralAMG_MGL_Coarsener::do_construct_coarse_subspace(const mfem::Vector&
                                        Pu_, Psigma_, face_facedof_table_,
                                        *coarse_m_builder_, constant_rep);
 
-    CoarseD_ = graph_coarsen_->GetCoarseD();
-    CoarseW_ = graph_coarsen_->GetCoarseW();
+    coarse_D_ = graph_coarsen_->GetCoarseD();
+    coarse_W_ = graph_coarsen_->GetCoarseW();
 }
 
 } // namespace smoothg

--- a/src/SpectralAMG_MGL_Coarsener.cpp
+++ b/src/SpectralAMG_MGL_Coarsener.cpp
@@ -31,23 +31,29 @@ namespace smoothg
 {
 
 SpectralAMG_MGL_Coarsener::SpectralAMG_MGL_Coarsener(const MixedMatrix& mgL,
-                                                     GraphTopology gt,
-                                                     const UpscaleParameters& param)
-    : Mixed_GL_Coarsener(mgL, std::move(gt)),
-      param_(param)
+                                                     const UpscaleParameters& param,
+                                                     const mfem::Array<int>* partitioning)
+    : Mixed_GL_Coarsener(mgL), param_(param), partitioning_(partitioning)
 {
 }
 
 void SpectralAMG_MGL_Coarsener::do_construct_coarse_subspace(const mfem::Vector& constant_rep)
 {
+    if (partitioning_)
+    {
+        coarse_graph_ = graph_topology_.Coarsen(*partitioning_);
+    }
+    else
+    {
+        coarse_graph_ = graph_topology_.Coarsen(param_.coarse_factor);
+    }
+
     using LMGST = LocalMixedGraphSpectralTargets;
 
     std::vector<mfem::DenseMatrix> local_edge_traces;
     std::vector<mfem::DenseMatrix> local_spectral_vertex_targets;
 
-    LMGST localtargets(param_.spect_tol, param_.max_evects, param_.dual_target,
-                       param_.scaled_dual, param_.energy_dual, mgL_.GetM(),
-                       mgL_.GetD(), mgL_.GetW(), graph_topology_);
+    LMGST localtargets(mgL_, graph_topology_, param_);
     localtargets.Compute(local_edge_traces, local_spectral_vertex_targets,
                          constant_rep);
 

--- a/src/SpectralAMG_MGL_Coarsener.hpp
+++ b/src/SpectralAMG_MGL_Coarsener.hpp
@@ -44,8 +44,8 @@ public:
        @param param upscaling parameters
     */
     SpectralAMG_MGL_Coarsener(const MixedMatrix& mgL,
-                              GraphTopology gt,
-                              const UpscaleParameters& param = UpscaleParameters());
+                              const UpscaleParameters& param = UpscaleParameters(),
+                              const mfem::Array<int>* partitioning = nullptr);
 
 private:
     /**
@@ -57,6 +57,7 @@ private:
 
 private:
     const UpscaleParameters& param_;
+    const mfem::Array<int>* partitioning_;
 }; // SpectralAMG_MGL_Coarsener
 
 } // namespace smoothg

--- a/src/Upscale.cpp
+++ b/src/Upscale.cpp
@@ -170,7 +170,7 @@ void Upscale::Mult(int level, const mfem::Vector& x, mfem::Vector& y) const
     rhs_[0]->GetBlock(1) = x;
     for (int i = 0; i < level; ++i)
     {
-        coarsener_[i]->restrict(rhs_[i]->GetBlock(1), rhs_[i + 1]->GetBlock(1));
+        coarsener_[i]->Restrict(rhs_[i]->GetBlock(1), rhs_[i + 1]->GetBlock(1));
     }
 
     // solve
@@ -188,7 +188,7 @@ void Upscale::Mult(int level, const mfem::Vector& x, mfem::Vector& y) const
     // interpolate solution
     for (int i = level - 1; i >= 0; --i)
     {
-        coarsener_[i]->interpolate(sol_[i + 1]->GetBlock(1), sol_[i]->GetBlock(1));
+        coarsener_[i]->Interpolate(sol_[i + 1]->GetBlock(1), sol_[i]->GetBlock(1));
     }
     y = sol_[0]->GetBlock(1);
     Orthogonalize(0, y);
@@ -222,7 +222,7 @@ void Upscale::Solve(int level, const mfem::BlockVector& x, mfem::BlockVector& y)
     *rhs_[0] = x;
     for (int i = 0; i < level; ++i)
     {
-        coarsener_[i]->restrict(*rhs_[i], * rhs_[i + 1]);
+        coarsener_[i]->Restrict(*rhs_[i], * rhs_[i + 1]);
     }
 
     // solve
@@ -236,7 +236,7 @@ void Upscale::Solve(int level, const mfem::BlockVector& x, mfem::BlockVector& y)
     // interpolate solution
     for (int i = level - 1; i >= 0; --i)
     {
-        coarsener_[i]->interpolate(*sol_[i + 1], *sol_[i]);
+        coarsener_[i]->Interpolate(*sol_[i + 1], *sol_[i]);
     }
     y = *sol_[0];
 }
@@ -287,7 +287,7 @@ mfem::BlockVector Upscale::SolveAtLevel(int level, const mfem::BlockVector& x) c
 void Upscale::Interpolate(int level, const mfem::Vector& x, mfem::Vector& y) const
 {
     assert(coarsener_[level - 1]);
-    coarsener_[level - 1]->interpolate(x, y);
+    coarsener_[level - 1]->Interpolate(x, y);
 }
 
 mfem::Vector Upscale::Interpolate(int level, const mfem::Vector& x) const
@@ -303,7 +303,7 @@ void Upscale::Interpolate(int level, const mfem::BlockVector& x, mfem::BlockVect
 {
     assert(coarsener_[level - 1]);
 
-    coarsener_[level - 1]->interpolate(x, y);
+    coarsener_[level - 1]->Interpolate(x, y);
 }
 
 mfem::BlockVector Upscale::Interpolate(int level, const mfem::BlockVector& x) const
@@ -319,7 +319,7 @@ void Upscale::Restrict(int level, const mfem::Vector& x, mfem::Vector& y) const
 {
     assert(coarsener_[level - 1]);
 
-    coarsener_[level - 1]->restrict(x, y);
+    coarsener_[level - 1]->Restrict(x, y);
 }
 
 mfem::Vector Upscale::Restrict(int level, const mfem::Vector& x) const
@@ -334,7 +334,7 @@ void Upscale::Restrict(int level, const mfem::BlockVector& x, mfem::BlockVector&
 {
     assert(coarsener_[level - 1]);
 
-    coarsener_[level - 1]->restrict(x, y);
+    coarsener_[level - 1]->Restrict(x, y);
 }
 
 mfem::BlockVector Upscale::Restrict(int level, const mfem::BlockVector& x) const
@@ -623,12 +623,12 @@ void Upscale::DumpDebug(const std::string& prefix) const
         s << prefix << "Psigma" << counter << ".sparsematrix";
         std::ofstream outPsigma(s.str().c_str());
         outPsigma << std::scientific << std::setprecision(15);
-        c->get_Psigma().Print(outPsigma, 1);
+        c->GetPsigma().Print(outPsigma, 1);
         s.str("");
         s << prefix << "Pu" << counter++ << ".sparsematrix";
         std::ofstream outPu(s.str().c_str());
         outPu << std::scientific << std::setprecision(15);
-        c->get_Pu().Print(outPu, 1);
+        c->GetPu().Print(outPu, 1);
     }
 }
 

--- a/src/Upscale.cpp
+++ b/src/Upscale.cpp
@@ -653,14 +653,7 @@ void Upscale::RescaleCoefficient(int level, const mfem::Vector& coeff)
 
 int Upscale::GetNumVertices(int level) const
 {
-    if (level == 0)
-    {
-        return rhs_[level]->GetBlock(1).Size();
-    }
-    else
-    {
-        return coarsener_[level - 1]->get_num_aggregates();
-    }
+    return GetMatrix(level).GetGraph().NumVertices();
 }
 
 std::vector<int> Upscale::GetVertexSizes() const

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -186,12 +186,12 @@ public:
 
     const mfem::SparseMatrix& GetPsigma(int level) const
     {
-        return coarsener_[level]->get_Psigma();
+        return coarsener_[level]->GetPsigma();
     }
 
     const mfem::SparseMatrix& GetPu(int level) const
     {
-        return coarsener_[level]->get_Pu();
+        return coarsener_[level]->GetPu();
     }
 
     /// Create Fine Level Solver

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -208,7 +208,7 @@ public:
 
 protected:
 
-    void Init(const Graph& graph, const mfem::Array<int>& partitioning);
+    void Init(const mfem::Array<int>* partitioning);
 
     void MakeVectors(int level)
     {

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -78,10 +78,8 @@ void UpscalingStatistics::ComputeErrorSquare(
     for (int j = k; j > 0; --j)
     {
         MFEM_ASSERT(j == 1, "Only a two-level method is considered");
-        mgLc.get_Psigma().Mult(help_[j]->GetBlock(0),
-                               help_[j - 1]->GetBlock(0));
-        mgLc.get_Pu().Mult(help_[j]->GetBlock(1),
-                           help_[j - 1]->GetBlock(1));
+        mgLc.GetPsigma().Mult(help_[j]->GetBlock(0), help_[j - 1]->GetBlock(0));
+        mgLc.GetPu().Mult(help_[j]->GetBlock(1), help_[j - 1]->GetBlock(1));
     }
 
     if (!mgL[0].CheckW())
@@ -93,8 +91,7 @@ void UpscalingStatistics::ComputeErrorSquare(
     for (int j(0); j <= k; ++j)
     {
         MFEM_ASSERT(help_[j]->Size() == sol[j]->Size() &&
-                    sol[j]->GetBlock(0).Size()
-                    == mgL[j].GetD().Width(),
+                    sol[j]->GetBlock(0).Size() == mgL[j].GetD().Width(),
                     "Graph Laplacian");
 
         int sigmasize = sol[0]->GetBlock(0).Size();

--- a/testcode/rescaling.cpp
+++ b/testcode/rescaling.cpp
@@ -88,12 +88,13 @@ mfem::SparseMatrix RescaledFineM(mfem::FiniteElementSpace& sigmafespace,
     return mfem::SparseMatrix(a1.SpMat());
 }
 
-unique_ptr<SpectralAMG_MGL_Coarsener> BuildCoarsener(mfem::SparseMatrix& v_e,
+unique_ptr<SpectralAMG_MGL_Coarsener> BuildCoarsener(const Graph& graph,
                                                      const MixedMatrix& mgL,
                                                      const mfem::Array<int>& partition,
                                                      const mfem::SparseMatrix* edge_bdratt)
 {
-    GraphTopology gt(v_e, mgL.GetEdgeDofToTrueDof(), partition, edge_bdratt);
+    GraphTopology gt(graph, edge_bdratt);
+    gt.Coarsen(partition);
     UpscaleParameters param;
     param.spect_tol = 1.0;
     param.max_evects = 3;
@@ -163,7 +164,7 @@ int main(int argc, char* argv[])
     MixedMatrix fine_mgL(graph);
 
     // Create a coarsener to build interpolation matrices and coarse M builder
-    auto coarsener = BuildCoarsener(vertex_edge, fine_mgL, partitioning, &edge_bdratt);
+    auto coarsener = BuildCoarsener(graph, fine_mgL, partitioning, &edge_bdratt);
 
     // Interpolate agg scaling (coarse level) to elements (fine level)
     mfem::Vector interp_agg_scale(pmesh->GetNE());

--- a/testcode/rescaling.cpp
+++ b/testcode/rescaling.cpp
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
 
     // Assembled rescaled fine and coarse M through direct assembling and RAP
     auto fine_M2 = RescaledFineM(sigmafespace, elem_scale, interp_agg_scale);
-    auto& Psigma = coarsener->get_Psigma();
+    auto& Psigma = coarsener->GetPsigma();
     unique_ptr<mfem::SparseMatrix> coarse_M2(mfem::RAP(Psigma, fine_M2, Psigma));
 
     // Check relative differences measured in Frobenius norm


### PR DESCRIPTION
This PR is a step to make `Mixed_GL_Coarsener` an "intermediate" tool for coarsening. The goal is that we do not need to keep them (in a multilevel hierarchy). Only the mixed systems and interpolation matrices will be kept. This PR only deals with `GraphTopology`. Like coarsener, the relation tables between levels are needed only at the time of coarsening, we do not need to keep them.

Reorganize `GraphTopology`: 
1. Separate relation tables that describe fine graph, relation tables that describe coarse graph, and relation tables that describe the connection between fine and coarse graphs. Only the last group is left explicitly in `GraphTopology`. The fine graph is given from input and can be accessed through a raw pointer, and the coarse graph will be output from `GraphTopology::Coarsen`.
2. Construct `GraphTopology` inside `SpectralAMG_MGL_Coarsener` because it is part of the coarsening algorithm.
3. Unify `GraphTopology`constructors. The constructor that takes a coarse graph (GraphTopology) as input is now not needed, as the coarse graph is separated from `GraphTopology` (of previous level), so it is viewed just like another graph. The other "partial constructor" is also removed. It was only used in `lineargraph` as a test for using some manually constructed topology relations. Although the constructor is removed, this test is still doing the same thing. The `GraphTopology` is constructed from fine graph (no coarsening in this stage). The relation tables in `GraphTopology` are then copied from the manually constructed ones.

Minor: there are also some renaming/removal of members/functions in `Mixed_GL_Coarsener`.


