### PR TITLE
Multilevel sampling [working/combine multilevel refactor]

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -121,6 +121,7 @@ else()
 endif()
 add_test(isolate_coarsen python stest.py isolate-coarsen)
 add_test(sampler python stest.py sampler)
+add_test(ml-sampler python stest.py ml-sampler)
 
 add_test(vgraph-small-usegenerator python stest.py vgraph-small-usegenerator)
 add_test(vgraph-small-usegenerator-hb python stest.py vgraph-small-usegenerator-hb)

--- a/examples/mlmc.cpp
+++ b/examples/mlmc.cpp
@@ -282,8 +282,8 @@ int main(int argc, char* argv[])
     unique_ptr<MultilevelSampler> sampler;
     if (std::string(sampler_type) == "simple")
     {
-        MFEM_ASSERT(num_levels == 2, "SimpleSampler only implemented 2-level here!");
-        sampler = make_unique<SimpleSampler>(vertex_edge.Height(), partitioning.Max() + 1);
+        std::vector<int> vertex_sizes = upscale.GetVertexSizes();
+        sampler = make_unique<SimpleSampler>(vertex_sizes);
     }
     else if (std::string(sampler_type) == "pde")
     {

--- a/examples/mlmc.cpp
+++ b/examples/mlmc.cpp
@@ -25,6 +25,9 @@
    ./mlmc --perm spe_perm.dat
 */
 
+// best multilevel command line so far (appears to create a reasonable result):
+// ./mlmc --sampler-type pde --num-samples 2 --max-levels 3 --hybridization --no-coarse-components --max-evects 1 --coarse-factor 8
+
 #include <fstream>
 #include <sstream>
 #include <mpi.h>

--- a/examples/mlmc.cpp
+++ b/examples/mlmc.cpp
@@ -283,7 +283,7 @@ int main(int argc, char* argv[])
         std::cout << "fine graph vertices = " << num_fine_vertices << ", fine graph edges = "
                   << num_fine_edges << ", coarse aggregates = " << num_aggs << std::endl;
     }
-    unique_ptr<TwoLevelSampler> sampler;
+    unique_ptr<MultilevelSampler> sampler;
     if (std::string(sampler_type) == "simple")
     {
         sampler = make_unique<SimpleSampler>(num_fine_vertices, num_aggs);
@@ -310,12 +310,12 @@ int main(int argc, char* argv[])
 
         sampler->NewSample();
 
-        auto coarse_coefficient = sampler->GetCoarseCoefficient();
+        auto coarse_coefficient = sampler->GetCoefficient(1);
         upscale.RescaleCoarseCoefficient(coarse_coefficient);
         auto sol_upscaled = upscale.Solve(1, rhs_fine);
         upscale.ShowSolveInfo(1);
 
-        auto fine_coefficient = sampler->GetFineCoefficient();
+        auto fine_coefficient = sampler->GetCoefficient(0);
         upscale.RescaleFineCoefficient(fine_coefficient);
         auto sol_fine = upscale.Solve(0, rhs_fine);
         upscale.ShowSolveInfo(0);

--- a/examples/mlmc.cpp
+++ b/examples/mlmc.cpp
@@ -275,18 +275,12 @@ int main(int argc, char* argv[])
     rhs_fine.GetBlock(0) = 0.0;
     rhs_fine.GetBlock(1) = rhs_u_fine;
 
-    const int num_fine_vertices = vertex_edge.Height();
-    const int num_fine_edges = vertex_edge.Width();
-    const int num_aggs = partitioning.Max() + 1; // this can be wrong if there are empty partitions
-    if (myid == 0)
-    {
-        std::cout << "fine graph vertices = " << num_fine_vertices << ", fine graph edges = "
-                  << num_fine_edges << ", coarse aggregates = " << num_aggs << std::endl;
-    }
+    const int num_levels = upscale_param.max_levels;
     unique_ptr<MultilevelSampler> sampler;
     if (std::string(sampler_type) == "simple")
     {
-        sampler = make_unique<SimpleSampler>(num_fine_vertices, num_aggs);
+        MFEM_ASSERT(num_levels == 2, "SimpleSampler only implemented 2-level here!");
+        sampler = make_unique<SimpleSampler>(vertex_edge.Height(), partitioning.Max() + 1);
     }
     else if (std::string(sampler_type) == "pde")
     {
@@ -309,52 +303,50 @@ int main(int argc, char* argv[])
             std::cout << "---\nSample " << sample << "\n---" << std::endl;
 
         sampler->NewSample();
+        std::vector<mfem::Vector> coefficient(num_levels);
+        std::vector<mfem::BlockVector> sol;
 
-        auto coarse_coefficient = sampler->GetCoefficient(1);
-        upscale.RescaleCoarseCoefficient(coarse_coefficient);
-        auto sol_upscaled = upscale.Solve(1, rhs_fine);
-        upscale.ShowSolveInfo(1);
-
-        auto fine_coefficient = sampler->GetCoefficient(0);
-        upscale.RescaleFineCoefficient(fine_coefficient);
-        auto sol_fine = upscale.Solve(0, rhs_fine);
-        upscale.ShowSolveInfo(0);
-
-        auto error_info = upscale.ComputeErrors(sol_upscaled, sol_fine);
-
-        if (myid == 0)
+        for (int level = 0; level < num_levels; ++level)
         {
-            ShowErrors(error_info);
+            coefficient[level] = sampler->GetCoefficient(level);
+            upscale.RescaleCoefficient(level, coefficient[level]);
+            sol.push_back(upscale.Solve(level, rhs_fine));
+            upscale.ShowSolveInfo(level);
+
+            if (level > 0)
+            {
+                auto error_info = upscale.ComputeErrors(sol[level], sol[0]);
+                if (myid == 0)
+                    ShowErrors(error_info);
+            }
+
+            std::stringstream filename;
+            filename << "pressure_s" << sample << "_l" << level;
+            SaveFigure(sol[level].GetBlock(1), ufespace, filename.str());
+            if (visualization)
+            {
+                mfem::ParGridFunction field(&ufespace);
+                std::stringstream caption;
+                caption << "pressure sample " << sample << " level " << level;
+                Visualize(sol[level].GetBlock(1), field, *pmesh, caption.str());
+            }
         }
 
         // for more informative visualization
-        for (int i = 0; i < fine_coefficient.Size(); ++i)
+        for (int i = 0; i < coefficient[0].Size(); ++i)
         {
-            fine_coefficient[i] = std::log(fine_coefficient[i]);
+            coefficient[0](i) = std::log(coefficient[0](i));
         }
-
-        std::stringstream coarsename;
-        coarsename << "upscaledpressure" << sample;
-        SaveFigure(sol_upscaled.GetBlock(1), ufespace, coarsename.str());
-        std::stringstream finename;
-        finename << "finepressure" << sample;
-        SaveFigure(sol_fine.GetBlock(1), ufespace, finename.str());
         std::stringstream coeffname;
         coeffname << "coefficient" << sample;
-        SaveFigure(fine_coefficient, ufespace, coeffname.str());
+        SaveFigure(coefficient[0], ufespace, coeffname.str());
 
-        // Visualize the solution
         if (visualization)
         {
             mfem::ParGridFunction field(&ufespace);
-
-            std::stringstream ss1, ss2, ss3;
-            ss1 << "upscaled pressure" << sample;
-            Visualize(sol_upscaled.GetBlock(1), field, *pmesh, ss1.str());
-            ss2 << "fine pressure" << sample;
-            Visualize(sol_fine.GetBlock(1), field, *pmesh, ss2.str());
-            ss3 << "coefficient" << sample;
-            Visualize(fine_coefficient, field, *pmesh, ss3.str());
+            std::stringstream caption;
+            caption << "coefficient" << sample;
+            Visualize(coefficient[0], field, *pmesh, caption.str());
         }
     }
 

--- a/examples/readjson.py
+++ b/examples/readjson.py
@@ -29,7 +29,7 @@ import json
 import sys
 
 
-def json_parse_lines(lines, max_depth=10, max_height=6):
+def json_parse_lines(lines, max_depth=10, max_height=36):
     for index in range(-1, -max_depth, -1):
         for i in range(max_height):
             try:

--- a/examples/sampler.cpp
+++ b/examples/sampler.cpp
@@ -338,22 +338,19 @@ int main(int argc, char* argv[])
             if (level == 1)
             {
                 max_p_error = (max_p_error > p_error[level]) ? max_p_error : p_error[level];
+            }
 
-                if (save_samples)
+            if (save_samples)
+            {
+                std::stringstream name;
+                name << "sample_l" << level << "_s" << sample;
+                if (level == 0)
                 {
-                    std::stringstream coarsename;
-                    coarsename << "coarse_" << sample;
-                    SaveFigure(sol_upscaled, ufespace, coarsename.str());
-                    std::stringstream finename;
-                    finename << "fine_" << sample;
-                    SaveFigure(sol_fine, ufespace, finename.str());
+                    SaveFigure(sol_fine, ufespace, name.str());
                 }
-
+                else
                 {
-                    //std::cout << "    fine: iterations: " << fine_iterations
-                    // << ", time: " << fine_time << std::endl;
-                    // std::cout << "    coarse: iterations: " << coarse_iterations
-                    // << ", time: " << coarse_time << std::endl;
+                    SaveFigure(sol_upscaled, ufespace, name.str());
                 }
             }
         }
@@ -401,10 +398,15 @@ int main(int argc, char* argv[])
     }
     if (save_statistics)
     {
-        SaveFigure(mean[1], ufespace, "coarse_mean");
-        SaveFigure(mean[0], ufespace, "fine_mean");
-        SaveFigure(m2[1], ufespace, "coarse_variance");
-        SaveFigure(m2[0], ufespace, "fine_variance");
+        for (int level = 0; level < num_levels; ++level)
+        {
+            std::stringstream filename;
+            filename << "level_" << level << "_mean";
+            SaveFigure(mean[level], ufespace, filename.str());
+            filename.str("");
+            filename << "level_" << level << "_variance";
+            SaveFigure(m2[level], ufespace, filename.str());
+        }
     }
 
     if (myid == 0)

--- a/examples/sampler.cpp
+++ b/examples/sampler.cpp
@@ -31,6 +31,9 @@
    examples/sampler --visualization --kappa 0.001 --cartesian-factor 2
 */
 
+// previously used command line here for multilevel (vary kappa to see nice pictures)
+// ./sampler --visualization --kappa 0.001 --max-levels 3
+
 #include <fstream>
 #include <sstream>
 #include <random>
@@ -96,6 +99,18 @@ void Visualize(const mfem::Vector& sol,
     vis_v << "keys cjl\n";
 
     MPI_Barrier(pmesh->GetComm());
+};
+
+mfem::Vector InterpolateToFine(const Upscale& upscale, int level, const mfem::Vector& in)
+{
+    mfem::Vector vec1, vec2;
+    vec1 = in;
+    for (int k = level; k > 0; k--)
+    {
+        vec2 = upscale.Interpolate(k, vec1);
+        vec2.Swap(vec1);
+    }
+    return vec1;
 }
 
 int main(int argc, char* argv[])
@@ -240,23 +255,25 @@ int main(int argc, char* argv[])
     const double cell_volume = spe10problem.CellVolume(nDimensions);
     W_block *= cell_volume * kappa * kappa;
 
-    mfem::Vector mean_fine(ufespace.GetVSize());
-    mean_fine = 0.0;
-    mfem::Vector mean_upscaled(ufespace.GetVSize());
-    mean_upscaled = 0.0;
-    mfem::Vector m2_fine(ufespace.GetVSize());
-    m2_fine = 0.0;
-    mfem::Vector m2_upscaled(ufespace.GetVSize());
-    m2_upscaled = 0.0;
-
-    int total_coarse_iterations = 0;
-    int total_fine_iterations = 0;
-    double total_coarse_time = 0.0;
-    double total_fine_time = 0.0;
-
-    Graph graph(vertex_edge, *edge_d_td, weight);
+    const int num_levels = upscale_param.max_levels;
+    std::vector<mfem::Vector> mean(num_levels);
+    std::vector<mfem::Vector> m2(num_levels);
+    std::vector<int> total_iterations(num_levels);
+    std::vector<double> total_time(num_levels);
+    std::vector<double> p_error(num_levels);
+    for (int level = 0; level < num_levels; ++level)
+    {
+        mean[level].SetSize(ufespace.GetVSize());
+        mean[level] = 0.0;
+        m2[level].SetSize(ufespace.GetVSize());
+        m2[level] = 0.0;
+        total_iterations[level] = 0;
+        total_time[level] = 0.0;
+    }
 
     // Create Upscaler
+    upscale_param.coarse_factor = 4;
+    Graph graph(vertex_edge, *edge_d_td, weight);
     auto upscale = std::make_shared<Upscale>(
                        graph, W_block, partitioning, &edge_boundary_att, &ess_attr, upscale_param);
 
@@ -264,113 +281,130 @@ int main(int argc, char* argv[])
     upscale->PrintInfo();
     upscale->ShowSetupTime();
 
-    const int num_aggs = partitioning.Max() + 1;
-    if (myid == 0)
-        std::cout << "Number of aggregates: " << num_aggs << std::endl;
-    PDESampler pdesampler(upscale, ufespace.GetVSize(), num_aggs, nDimensions,
-                          cell_volume, kappa, seed + myid);
+    PDESampler pdesampler(upscale, nDimensions, cell_volume, kappa, seed + myid);
+    // PDESampler pdesampler(upscale, ufespace.GetVSize(), num_aggs, nDimensions,
+    //                   cell_volume, kappa, seed + myid);
 
     double max_p_error = 0.0;
     for (int sample = 0; sample < num_samples; ++sample)
     {
-        double count = static_cast<double>(sample) + 1.0;
-        pdesampler.NewSample();
-
-        auto sol_coarse = pdesampler.GetCoarseCoefficientForVisualization();
-        auto sol_upscaled = upscale->Interpolate(1, sol_coarse);
-        for (int i = 0; i < sol_upscaled.Size(); ++i)
-            sol_upscaled(i) = std::log(sol_upscaled(i));
-        upscale->Orthogonalize(0, sol_upscaled);
-        int coarse_iterations = upscale->GetSolveIters(1);
-        total_coarse_iterations += coarse_iterations;
-        double coarse_time = upscale->GetSolveTime(1);
-        total_coarse_time += coarse_time;
-        for (int i = 0; i < mean_upscaled.Size(); ++i)
-        {
-            const double delta = (sol_upscaled(i) - mean_upscaled(i));
-            mean_upscaled(i) += delta / count;
-            const double delta2 = (sol_upscaled(i) - mean_upscaled(i));
-            m2_upscaled(i) += delta * delta2;
-        }
-
-        auto sol_fine = pdesampler.GetFineCoefficient();
-        for (int i = 0; i < sol_fine.Size(); ++i)
-            sol_fine(i) = std::log(sol_fine(i));
-        int fine_iterations = upscale->GetSolveIters(0);
-        total_fine_iterations += fine_iterations;
-        double fine_time = upscale->GetSolveTime(0);
-        total_fine_time += fine_time;
-        for (int i = 0; i < mean_fine.Size(); ++i)
-        {
-            const double delta = (sol_fine(i) - mean_fine(i));
-            mean_fine(i) += delta / count;
-            const double delta2 = (sol_fine(i) - mean_fine(i));
-            m2_fine(i) += delta * delta2;
-        }
-
-        double finest_p_error = CompareError(comm, sol_upscaled, sol_fine);
-        max_p_error = (max_p_error > finest_p_error) ? max_p_error : finest_p_error;
-
-        if (save_samples)
-        {
-            std::stringstream coarsename;
-            coarsename << "coarse_" << sample;
-            SaveFigure(sol_upscaled, ufespace, coarsename.str());
-            std::stringstream finename;
-            finename << "fine_" << sample;
-            SaveFigure(sol_fine, ufespace, finename.str());
-        }
-
         if (myid == 0)
         {
             std::cout << "  Sample " << sample << ":" << std::endl;
-            std::cout << "    fine: iterations: " << fine_iterations
-                      << ", time: " << fine_time << std::endl;
-            std::cout << "    coarse: iterations: " << coarse_iterations
-                      << ", time: " << coarse_time << std::endl;
-            std::cout << "    p_error: " << finest_p_error << std::endl;
+        }
+        double count = static_cast<double>(sample) + 1.0;
+        pdesampler.NewSample();
+
+        auto sol_fine = pdesampler.GetCoefficient(0);
+        for (int i = 0; i < sol_fine.Size(); ++i)
+            sol_fine(i) = std::log(sol_fine(i));
+        int iterations = upscale->GetSolveIters(0);
+        total_iterations[0] += iterations;
+        double time = upscale->GetSolveTime(0);
+        total_time[0] += time;
+        for (int i = 0; i < mean[0].Size(); ++i)
+        {
+            const double delta = (sol_fine(i) - mean[0](i));
+            mean[0](i) += delta / count;
+            const double delta2 = (sol_fine(i) - mean[0](i));
+            m2[0](i) += delta * delta2;
+        }
+        p_error[0] = 0.0;
+
+        for (int level = 1; level < num_levels; ++level)
+        {
+            auto sol_coarse = pdesampler.GetCoefficientForVisualization(level);
+            auto sol_upscaled = InterpolateToFine(*upscale, level, sol_coarse);
+            for (int i = 0; i < sol_upscaled.Size(); ++i)
+                sol_upscaled(i) = std::log(sol_upscaled(i));
+            upscale->Orthogonalize(0, sol_upscaled);
+            iterations = upscale->GetSolveIters(level);
+            total_iterations[level] += iterations;
+            time = upscale->GetSolveTime(level);
+            total_time[level] += time;
+            for (int i = 0; i < mean[level].Size(); ++i)
+            {
+                const double delta = (sol_upscaled(i) - mean[level](i));
+                mean[level](i) += delta / count;
+                const double delta2 = (sol_upscaled(i) - mean[level](i));
+                m2[level](i) += delta * delta2;
+            }
+            p_error[level] = CompareError(comm, sol_upscaled, sol_fine);
+            if (myid == 0)
+            {
+                std::cout << "    p_error_level_" << level << ": " << p_error[level] << std::endl;
+            }
+
+            if (level == 1)
+            {
+                max_p_error = (max_p_error > p_error[level]) ? max_p_error : p_error[level];
+
+                if (save_samples)
+                {
+                    std::stringstream coarsename;
+                    coarsename << "coarse_" << sample;
+                    SaveFigure(sol_upscaled, ufespace, coarsename.str());
+                    std::stringstream finename;
+                    finename << "fine_" << sample;
+                    SaveFigure(sol_fine, ufespace, finename.str());
+                }
+
+                {
+                    //std::cout << "    fine: iterations: " << fine_iterations
+                    // << ", time: " << fine_time << std::endl;
+                    // std::cout << "    coarse: iterations: " << coarse_iterations
+                    // << ", time: " << coarse_time << std::endl;
+                }
+            }
         }
     }
 
     double count = static_cast<double>(num_samples);
     if (count > 1.1)
     {
-        m2_upscaled *= (1.0 / (count - 1.0));
-        m2_fine *= (1.0 / (count - 1.0));
+        for (int level = 0; level < num_levels; ++level)
+            m2[level] *= (1.0 / (count - 1.0));
     }
 
-    serialize["total-coarse-iterations"] = picojson::value((double) total_coarse_iterations);
-    serialize["total-fine-iterations"] = picojson::value((double) total_fine_iterations);
+    serialize["total-coarse-iterations"] = picojson::value((double) total_iterations[1]);
+    serialize["total-fine-iterations"] = picojson::value((double) total_iterations[0]);
     serialize["fine-mean-typical"] = picojson::value(
-                                         mean_fine[mean_fine.Size() / 2]);
+                                         mean[0][mean[0].Size() / 2]);
     serialize["fine-mean-l1"] = picojson::value(
-                                    mean_fine.Norml1() / static_cast<double>(mean_fine.Size()));
+                                    mean[0].Norml1() / static_cast<double>(mean[0].Size()));
     serialize["coarse-mean-l1"] = picojson::value(
-                                      mean_upscaled.Norml1() / static_cast<double>(mean_upscaled.Size()));
+                                      mean[1].Norml1() / static_cast<double>(mean[1].Size()));
     serialize["coarse-mean-typical"] = picojson::value(
-                                           mean_upscaled[mean_upscaled.Size() / 2]);
+                                           mean[1][mean[1].Size() / 2]);
     serialize["fine-variance-mean"] = picojson::value(
-                                          m2_fine.Sum() / static_cast<double>(m2_fine.Size()));
+                                          m2[0].Sum() / static_cast<double>(m2[0].Size()));
     serialize["coarse-variance-mean"] = picojson::value(
-                                            m2_upscaled.Sum() / static_cast<double>(m2_upscaled.Size()));
+                                            m2[1].Sum() / static_cast<double>(m2[1].Size()));
     serialize["max-p-error"] = picojson::value(max_p_error);
+    for (int i = 0; i < num_levels; ++i)
+    {
+        std::stringstream s;
+        s << "p-error-level-" << i;
+        serialize[s.str()] = picojson::value(p_error[i]);
+    }
 
     if (visualization)
     {
-        Visualize(mean_upscaled, ufespace, 1);
-        Visualize(mean_fine, ufespace, 0);
-        if (count > 1.1)
+        for (int level = 0; level < num_levels; ++level)
         {
-            Visualize(m2_upscaled, ufespace, 11);
-            Visualize(m2_fine, ufespace, 10);
+            Visualize(mean[level], ufespace, level);
+            if (count > 1.1)
+            {
+                Visualize(m2[level], ufespace, 10 + level);
+            }
         }
     }
     if (save_statistics)
     {
-        SaveFigure(mean_upscaled, ufespace, "coarse_mean");
-        SaveFigure(mean_fine, ufespace, "fine_mean");
-        SaveFigure(m2_upscaled, ufespace, "coarse_variance");
-        SaveFigure(m2_fine, ufespace, "fine_variance");
+        SaveFigure(mean[1], ufespace, "coarse_mean");
+        SaveFigure(mean[0], ufespace, "fine_mean");
+        SaveFigure(m2[1], ufespace, "coarse_variance");
+        SaveFigure(m2[0], ufespace, "fine_variance");
     }
 
     if (myid == 0)

--- a/examples/stest.py
+++ b/examples/stest.py
@@ -644,7 +644,14 @@ def make_tests():
           "--kappa", "0.01",
           "--num-samples", "2"],
          {"fine-mean-l1": 0.54961180496539375,
-          "max-p-error": 0.39869063097389679}]
+          "p-error-level-1": 0.39869063097389679}]
+
+    tests["ml-sampler"] = \
+        [["./sampler",
+          "--num-samples", "1",
+          "--max-levels", "3"],
+         {"p-error-level-1": 0.20833920382939719,
+          "p-error-level-2": 0.40118441747952621}]
 
     if "tux" in platform.node():
         tests["veigenvector"] = \

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -36,23 +36,13 @@ double NormalDistribution::Sample()
     return out;
 }
 
-SimpleSampler::SimpleSampler(int fine_size, int coarse_size)
-    :
-    size_(2), sample_(-1), helper_(2)
-{
-    size_[0] = fine_size;
-    size_[1] = coarse_size;
-    helper_[0].SetSize(size_[0]);
-    helper_[1].SetSize(size_[1]);
-}
-
 SimpleSampler::SimpleSampler(std::vector<int>& size)
     :
-    size_(size), sample_(-1)
+    sample_(-1), helper_(size.size())
 {
     for (unsigned int level = 0; level < size.size(); ++level)
     {
-        helper_[level].SetSize(size_[level]);
+        helper_[level].SetSize(size[level]);
     }
 }
 

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -182,6 +182,8 @@ mfem::Vector& PDESampler::GetFineCoefficient()
 
    indexing: the indexing above is wrong if there is more than one dof / aggregate,
              we consider only the coefficient for the *constant* component i
+
+   @todo: not working multilevel unless restricted to one eigenvector / agg (which maybe is the only sensible case for sampling anyway?)
 */
 mfem::Vector& PDESampler::GetCoefficient(int level)
 {

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -38,10 +38,22 @@ double NormalDistribution::Sample()
 
 SimpleSampler::SimpleSampler(int fine_size, int coarse_size)
     :
-    fine_size_(fine_size), coarse_size_(coarse_size), sample_(-1)
+    size_(2), sample_(-1), helper_(2)
 {
-    fine_.SetSize(fine_size_);
-    coarse_.SetSize(coarse_size_);
+    size_[0] = fine_size;
+    size_[1] = coarse_size;
+    helper_[0].SetSize(size_[0]);
+    helper_[1].SetSize(size_[1]);
+}
+
+SimpleSampler::SimpleSampler(std::vector<int>& size)
+    :
+    size_(size), sample_(-1)
+{
+    for (unsigned int level = 0; level < size.size(); ++level)
+    {
+        helper_[level].SetSize(size_[level]);
+    }
 }
 
 void SimpleSampler::NewSample()
@@ -49,31 +61,29 @@ void SimpleSampler::NewSample()
     sample_++;
 }
 
-const mfem::Vector& SimpleSampler::GetFineCoefficient()
+mfem::Vector& SimpleSampler::GetCoefficient(int level)
 {
     MFEM_ASSERT(sample_ >= 0, "SimpleSampler in wrong state (call NewSample() first)!");
-    fine_ = (1.0 + sample_);
-    return fine_;
+    helper_[level] = (1.0 + sample_);
+    return helper_[level];
 }
 
-mfem::Vector& SimpleSampler::GetCoarseCoefficient()
-{
-    MFEM_ASSERT(sample_ >= 0, "SimpleSampler in wrong state (call NewSample() first)!");
-    coarse_ = (1.0 + sample_);
-    return coarse_;
-}
-
-PDESampler::PDESampler(std::shared_ptr<const Upscale> fvupscale, int fine_vector_size,
-                       int coarse_aggs, int dimension, double cell_volume, double kappa,
+PDESampler::PDESampler(std::shared_ptr<Upscale> fvupscale,
+                       int dimension, double cell_volume, double kappa,
                        int seed)
     :
     fvupscale_(fvupscale),
     normal_distribution_(0.0, 1.0, seed),
-    fine_vector_size_(fine_vector_size),
-    num_coarse_aggs_(coarse_aggs),
+    num_aggs_(fvupscale->GetNumLevels()),
     cell_volume_(cell_volume),
-    current_state_(NO_SAMPLE)
+    sampled_(false),
+    rhs_(fvupscale->GetNumLevels()),
+    coefficient_(fvupscale->GetNumLevels())
 {
+    for (int level = 0; level < fvupscale->GetNumLevels(); ++level)
+    {
+        num_aggs_[level] = fvupscale->GetNumVertices(level);
+    }
     Initialize(dimension, kappa);
 }
 
@@ -88,26 +98,36 @@ PDESampler::PDESampler(MPI_Comm comm, int dimension,
                        const UpscaleParameters& param)
     :
     normal_distribution_(0.0, 1.0, seed),
-    fine_vector_size_(vertex_edge.Height()),
-    num_coarse_aggs_(partitioning.Max() + 1),
+    num_aggs_(param.max_levels),
     cell_volume_(cell_volume),
-    current_state_(NO_SAMPLE)
+    sampled_(false),
+    rhs_(param.max_levels),
+    coefficient_(param.max_levels)
 {
     mfem::SparseMatrix W_block = SparseIdentity(vertex_edge.Height());
     W_block *= cell_volume_ * kappa * kappa;
 
     graph_ = Graph(vertex_edge, edge_d_td, weight);
-    fvupscale_ = std::make_shared<Upscale>(graph_, W_block, partitioning,
-                                           &edge_boundary_att, &ess_attr, param);
+    fvupscale_ = std::make_shared<Upscale>(
+                     graph_, W_block, partitioning, &edge_boundary_att, &ess_attr,
+                     param);
+    fvupscale_->MakeFineSolver();
+
+    for (int level = 0; level < fvupscale_->GetNumLevels(); ++level)
+    {
+        num_aggs_[level] = fvupscale_->GetNumVertices(level);
+    }
     Initialize(dimension, kappa);
 }
 
 void PDESampler::Initialize(int dimension, double kappa)
 {
-    rhs_fine_.SetSize(fine_vector_size_);
-    coefficient_fine_.SetSize(fine_vector_size_);
-    rhs_coarse_ = fvupscale_->GetVector(1);
-    coefficient_coarse_.SetSize(num_coarse_aggs_);
+    for (int level = 0; level < fvupscale_->GetNumLevels(); ++level)
+    {
+        // rhs_[level] = fvupscale_->GetVector(level);
+        rhs_[level].SetSize(num_aggs_[level]);
+        coefficient_[level].SetSize(num_aggs_[level]);
+    }
 
     double nu_parameter;
     MFEM_ASSERT(dimension == 2 || dimension == 3, "Invalid dimension!");
@@ -127,34 +147,26 @@ PDESampler::~PDESampler()
 /// @todo cell_volume should be variable rather than constant
 void PDESampler::NewSample()
 {
-    current_state_ = FINE_SAMPLE;
+    sampled_ = true;
 
     // construct white noise right-hand side
     // (cell_volume is supposed to represent fine-grid W_h)
-    for (int i = 0; i < fine_vector_size_; ++i)
+    for (int i = 0; i < num_aggs_[0]; ++i)
     {
-        rhs_fine_(i) = scalar_g_ * std::sqrt(cell_volume_) *
-                       normal_distribution_.Sample();
+        rhs_[0](i) = scalar_g_ * std::sqrt(cell_volume_) *
+                     normal_distribution_.Sample();
     }
 }
 
-void PDESampler::NewCoarseSample()
+mfem::Vector& PDESampler::GetFineCoefficient()
 {
-    current_state_ = COARSE_SAMPLE;
-    MFEM_ASSERT(false, "Not implemented!");
-}
-
-const mfem::Vector& PDESampler::GetFineCoefficient()
-{
-    MFEM_ASSERT(current_state_ == FINE_SAMPLE,
-                "PDESampler object in wrong state (call NewSample() first)!");
-
-    fvupscale_->Solve(0, rhs_fine_, coefficient_fine_);
-    for (int i = 0; i < coefficient_fine_.Size(); ++i)
+    const int level = 0;
+    fvupscale_->Solve(level, rhs_[level], coefficient_[level]);
+    for (int i = 0; i < coefficient_[level].Size(); ++i)
     {
-        coefficient_fine_(i) = std::exp(coefficient_fine_(i));
+        coefficient_[level](i) = std::exp(coefficient_[level](i));
     }
-    return coefficient_fine_;
+    return coefficient_[level];
 }
 
 /**
@@ -171,19 +183,25 @@ const mfem::Vector& PDESampler::GetFineCoefficient()
    indexing: the indexing above is wrong if there is more than one dof / aggregate,
              we consider only the coefficient for the *constant* component i
 */
-mfem::Vector& PDESampler::GetCoarseCoefficient()
+mfem::Vector& PDESampler::GetCoefficient(int level)
 {
-    MFEM_ASSERT(current_state_ == FINE_SAMPLE ||
-                current_state_ == COARSE_SAMPLE,
+    MFEM_ASSERT(sampled_,
                 "PDESampler object in wrong state (call NewSample() first)!");
 
-    if (current_state_ == FINE_SAMPLE)
-        fvupscale_->Restrict(1, rhs_fine_, rhs_coarse_);
-    mfem::Vector coarse_sol = fvupscale_->GetVector(1);
-    fvupscale_->SolveAtLevel(1, rhs_coarse_, coarse_sol);
+    if (level == 0)
+    {
+        return GetFineCoefficient();
+    }
 
-    coefficient_coarse_ = 0.0;
-    mfem::Vector coarse_constant_rep = fvupscale_->GetConstantRep(1);
+    for (int k = 0; k < level; ++k)
+    {
+        fvupscale_->Restrict(k + 1, rhs_[k], rhs_[k + 1]);
+    }
+    mfem::Vector coarse_sol = fvupscale_->GetVector(level);
+    fvupscale_->SolveAtLevel(level, rhs_[level], coarse_sol);
+
+    coefficient_[level] = 0.0;
+    mfem::Vector coarse_constant_rep = fvupscale_->GetConstantRep(level);
     MFEM_ASSERT(coarse_constant_rep.Size() == coarse_sol.Size(),
                 "PDESampler::GetCoarseCoefficient : Sizes do not match!");
     int agg_index = 0;
@@ -191,43 +209,48 @@ mfem::Vector& PDESampler::GetCoarseCoefficient()
     {
         if (std::fabs(coarse_constant_rep(i)) > 1.e-8)
         {
-            coefficient_coarse_(agg_index++) =
+            coefficient_[level](agg_index++) =
                 std::exp(coarse_sol(i) / coarse_constant_rep(i));
         }
     }
-    MFEM_ASSERT(agg_index == num_coarse_aggs_, "Something wrong in coarse_constant_rep!");
+    MFEM_ASSERT(agg_index == num_aggs_[level], "Something wrong in coarse_constant_rep!");
 
-    return coefficient_coarse_;
+    return coefficient_[level];
 }
 
-mfem::Vector& PDESampler::GetCoarseCoefficientForVisualization()
+mfem::Vector& PDESampler::GetCoefficientForVisualization(int level)
 {
-    MFEM_ASSERT(current_state_ == FINE_SAMPLE ||
-                current_state_ == COARSE_SAMPLE,
+    MFEM_ASSERT(sampled_,
                 "PDESampler object in wrong state (call NewSample() first)!");
+    if (level == 0)
+    {
+        return GetFineCoefficient();
+    }
 
-    if (current_state_ == FINE_SAMPLE)
-        fvupscale_->Restrict(1, rhs_fine_, rhs_coarse_);
-    coefficient_coarse_.SetSize(rhs_coarse_.Size());
-    fvupscale_->SolveAtLevel(1, rhs_coarse_, coefficient_coarse_);
+    for (int i = 0; i < level; ++i)
+    {
+        fvupscale_->Restrict(i + 1, rhs_[i], rhs_[i + 1]);
+    }
+    coefficient_[level].SetSize(rhs_[level].Size());
+    fvupscale_->SolveAtLevel(level, rhs_[level], coefficient_[level]);
 
-    const mfem::Vector& coarse_constant_rep = fvupscale_->GetConstantRep(1);
-    MFEM_ASSERT(coarse_constant_rep.Size() == coefficient_coarse_.Size(),
+    const mfem::Vector& coarse_constant_rep = fvupscale_->GetConstantRep(level);
+    MFEM_ASSERT(coarse_constant_rep.Size() == coefficient_[level].Size(),
                 "PDESampler::GetCoarseCoefficient : Sizes do not match!");
-    for (int i = 0; i < coefficient_coarse_.Size(); ++i)
+    for (int i = 0; i < coefficient_[level].Size(); ++i)
     {
         if (std::fabs(coarse_constant_rep(i)) > 1.e-8)
         {
-            coefficient_coarse_(i) =
-                std::exp(coefficient_coarse_(i) / coarse_constant_rep(i)) * coarse_constant_rep(i);
+            coefficient_[level](i) =
+                std::exp(coefficient_[level](i) / coarse_constant_rep(i)) * coarse_constant_rep(i);
         }
         else
         {
-            coefficient_coarse_(i) = 0.0;
+            coefficient_[level](i) = 0.0;
         }
     }
 
-    return coefficient_coarse_;
+    return coefficient_[level];
 }
 
 }

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -124,8 +124,8 @@ void PDESampler::Initialize(int dimension, double kappa)
 {
     for (int level = 0; level < fvupscale_->GetNumLevels(); ++level)
     {
-        // rhs_[level] = fvupscale_->GetVector(level);
-        rhs_[level].SetSize(num_aggs_[level]);
+        rhs_[level] = fvupscale_->GetVector(level);
+        // rhs_[level].SetSize(num_aggs_[level]);
         coefficient_[level].SetSize(num_aggs_[level]);
     }
 

--- a/src/Sampler.hpp
+++ b/src/Sampler.hpp
@@ -66,7 +66,6 @@ public:
 class SimpleSampler : public MultilevelSampler
 {
 public:
-    SimpleSampler(int fine_size, int coarse_size);
     SimpleSampler(std::vector<int>& size);
 
     void NewSample();
@@ -74,8 +73,6 @@ public:
     mfem::Vector& GetCoefficient(int level);
 
 private:
-    std::vector<int> size_;
-
     int sample_;
 
     std::vector<mfem::Vector> helper_;

--- a/src/Sampler.hpp
+++ b/src/Sampler.hpp
@@ -43,10 +43,10 @@ private:
 /**
    Abstract class for drawing permeability samples.
 */
-class TwoLevelSampler
+class MultilevelSampler
 {
 public:
-    virtual ~TwoLevelSampler() {}
+    virtual ~MultilevelSampler() {}
 
     /**
        Pick a new sample; after calling this, GetFineCoefficient()
@@ -55,36 +55,30 @@ public:
     */
     virtual void NewSample() {}
 
-    /// return current sample realized on fine mesh
-    virtual const mfem::Vector& GetFineCoefficient() = 0;
-
     /// return current sample realized on coarse mesh
-    virtual mfem::Vector& GetCoarseCoefficient() = 0;
+    virtual mfem::Vector& GetCoefficient(int level) = 0;
 };
 
 /**
    Simply returns a constant coefficient, for testing some
    sampling and Monte Carlo stuff.
 */
-class SimpleSampler : public TwoLevelSampler
+class SimpleSampler : public MultilevelSampler
 {
 public:
     SimpleSampler(int fine_size, int coarse_size);
+    SimpleSampler(std::vector<int>& size);
 
     void NewSample();
 
-    const mfem::Vector& GetFineCoefficient();
-
-    mfem::Vector& GetCoarseCoefficient();
+    mfem::Vector& GetCoefficient(int level);
 
 private:
-    int fine_size_;
-    int coarse_size_;
+    std::vector<int> size_;
 
     int sample_;
 
-    mfem::Vector fine_;
-    mfem::Vector coarse_;
+    std::vector<mfem::Vector> helper_;
 };
 
 /**
@@ -94,7 +88,7 @@ private:
    hierarchical sampling technique for spatially correlated random fields,
    SISC 39 (2017) pp. S543-S562.
 */
-class PDESampler : public TwoLevelSampler
+class PDESampler : public MultilevelSampler
 {
 public:
     /**
@@ -115,8 +109,7 @@ public:
 
        @todo cell_volume should be potentially spatially-varying
     */
-    PDESampler(std::shared_ptr<const Upscale> upscale,
-               int fine_vector_size, int coarse_aggs,
+    PDESampler(std::shared_ptr<Upscale> upscale,
                int dimension, double cell_volume,
                double kappa, int seed);
 
@@ -152,44 +145,28 @@ public:
     /// Draw white noise on fine level
     void NewSample();
 
-    /// Draw white noise on coarse level
-    void NewCoarseSample();
+    /// Solve PDE with current white-noise RHS to find coeffiicent
+    /// on coarser level, the result is on *aggregates*
+    mfem::Vector& GetCoefficient(int level);
 
-    /// Solve PDE with current white-noise RHS to find fine coefficient
-    const mfem::Vector& GetFineCoefficient();
-
-    /// Solve PDE with current white-noise RHS to find coarse coeffiicent
-    /// this should be on *aggregates*
-    mfem::Vector& GetCoarseCoefficient();
-
-    /// Only for debugging/visualization, most users should use GetCoarseCoefficient
-    mfem::Vector& GetCoarseCoefficientForVisualization();
+    /// Only for debugging/visualization, most users should use GetCoefficient
+    mfem::Vector& GetCoefficientForVisualization(int level);
 
 private:
-    enum State
-    {
-        NO_SAMPLE,
-        FINE_SAMPLE,
-        COARSE_SAMPLE
-    };
-
-    // const Upscale& fvupscale_;
     Graph graph_;
-    std::shared_ptr<const Upscale> fvupscale_;
+    std::shared_ptr<Upscale> fvupscale_;
     NormalDistribution normal_distribution_;
-    int fine_vector_size_;
-    int num_coarse_aggs_;
+    std::vector<int> num_aggs_;
     double cell_volume_;
     double scalar_g_;
-    State current_state_;
+    bool sampled_;
 
     /// all these vectors live in the pressure / vertex space
-    mfem::Vector rhs_fine_;
-    mfem::Vector rhs_coarse_;
-    mfem::Vector coefficient_fine_;
-    mfem::Vector coefficient_coarse_;
+    std::vector<mfem::Vector> rhs_;
+    std::vector<mfem::Vector> coefficient_;
 
     void Initialize(int dimension, double kappa);
+    mfem::Vector& GetFineCoefficient();
 };
 
 }

--- a/src/Upscale.cpp
+++ b/src/Upscale.cpp
@@ -662,4 +662,26 @@ void Upscale::RescaleCoefficient(int level, const mfem::Vector& coeff)
     }
 }
 
+int Upscale::GetNumVertices(int level) const
+{
+    if (level == 0)
+    {
+        return rhs_[level]->GetBlock(1).Size();
+    }
+    else
+    {
+        return coarsener_[level - 1]->get_num_aggregates();
+    }
+}
+
+std::vector<int> Upscale::GetVertexSizes() const
+{
+    std::vector<int> out(GetNumLevels());
+    for (int level = 0; level < GetNumLevels(); ++level)
+    {
+        out[level] = GetNumVertices(level);
+    }
+    return out;
+}
+
 } // namespace smoothg

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -204,18 +204,12 @@ public:
     void RescaleCoefficient(int level, const mfem::Vector& coeff);
 
     int GetNumLevels() const { return rhs_.size(); }
-    int GetNumVertices(int level) const
-    {
-        // return rhs_[level]->GetBlock(1).Size();
-        if (level == 0)
-        {
-            return rhs_[level]->GetBlock(1).Size();
-        }
-        else
-        {
-            return coarsener_[level - 1]->get_num_aggregates();
-        }
-    }
+
+    /// returns the number of vertices at a given level
+    int GetNumVertices(int level) const;
+
+    /// return vector with number of vertices on each level
+    std::vector<int> GetVertexSizes() const;
 
 protected:
 

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -206,7 +206,18 @@ public:
     void RescaleCoefficient(int level, const mfem::Vector& coeff);
 
     int GetNumLevels() const { return rhs_.size(); }
-    int GetNumVertices(int level) const { return rhs_[level]->GetBlock(1).Size(); }
+    int GetNumVertices(int level) const
+    {
+        // return rhs_[level]->GetBlock(1).Size();
+        if (level == 0)
+        {
+            return rhs_[level]->GetBlock(1).Size();
+        }
+        else
+        {
+            return coarsener_[level - 1]->get_num_aggregates();
+        }
+    }
 
 protected:
 

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -201,12 +201,9 @@ public:
 
     void MakeSolver(int level);
 
-    /// coeff should have the size of the number of *vertices* in the fine graph
-    void RescaleFineCoefficient(const mfem::Vector& coeff);
-
     /// coeff should have the size of the number of *aggregates*
-    /// in the coarse graph
-    void RescaleCoarseCoefficient(const mfem::Vector& coeff);
+    /// in the coarse graph, or *vertices* in the finest graph
+    void RescaleCoefficient(int level, const mfem::Vector& coeff);
 
     int GetNumLevels() const { return rhs_.size(); }
     int GetNumVertices(int level) const { return rhs_[level]->GetBlock(1).Size(); }

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -208,6 +208,9 @@ public:
     /// in the coarse graph
     void RescaleCoarseCoefficient(const mfem::Vector& coeff);
 
+    int GetNumLevels() const { return rhs_.size(); }
+    int GetNumVertices(int level) const { return rhs_[level]->GetBlock(1).Size(); }
+
 protected:
 
     void Init(const Graph& graph, const mfem::Array<int>& partitioning);


### PR DESCRIPTION
This modifies the `PDESampler` object and the `sampler` and `mlmc` examples to be multilevel. It also adds a simple 3-level test for the `sampler` example.