### PR TITLE
bugfix for aggregate number in SetBubbleBubbleBlock [bugfix/BubbleBubbleBlock]

### DIFF
--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -498,13 +498,13 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
             B_potentials.GetColumnReference(l, ref_vec1);
             vertex_target_i.GetColumnReference(l + 1, ref_vec2);
             entry_value = smoothg::InnerProduct(ref_vec1, ref_vec2);
-            coarse_m_builder_->SetBubbleBubbleBlock(l, l, entry_value);
+            coarse_m_builder_->SetBubbleBubbleBlock(i, l, l, entry_value);
 
             for (int j = l + 1; j < num_bubbles_i; j++)
             {
                 vertex_target_i.GetColumnReference(j + 1, ref_vec2);
                 entry_value = smoothg::InnerProduct(ref_vec1, ref_vec2);
-                coarse_m_builder_->SetBubbleBubbleBlock(l, j, entry_value);
+                coarse_m_builder_->SetBubbleBubbleBlock(i, l, j, entry_value);
             }
         }
         bubble_counter += num_bubbles_i;

--- a/src/GraphCoarsenBuilder.cpp
+++ b/src/GraphCoarsenBuilder.cpp
@@ -108,9 +108,10 @@ void ElementMBuilder::AddTraceTraceBlock(int l, double value)
     M_el_loc(dof_loc_, edge_dof_markers_[0][l]) += value;
 }
 
-void ElementMBuilder::SetBubbleBubbleBlock(int l, int j, double value)
+void ElementMBuilder::SetBubbleBubbleBlock(int agg_index, int l,
+                                           int j, double value)
 {
-    mfem::DenseMatrix& M_el_loc(M_el_[agg_index_]);
+    mfem::DenseMatrix& M_el_loc(M_el_[agg_index]);
     M_el_loc(l, j) = value;
     M_el_loc(j, l) = value;
 }

--- a/src/GraphCoarsenBuilder.hpp
+++ b/src/GraphCoarsenBuilder.hpp
@@ -96,7 +96,8 @@ public:
     /// Deal with shared dofs for Trace-Trace block
     virtual void AddTraceAcross(int row, int col, int agg, double value) {}
 
-    virtual void SetBubbleBubbleBlock(int l, int j, double value) {}
+    virtual void SetBubbleBubbleBlock(int agg_index, int l, int j,
+                                      double value) {}
 
     virtual void ResetEdgeCdofMarkers(int size) {}
 
@@ -141,7 +142,7 @@ public:
     /// Deal with shared dofs for Trace-Trace block
     void AddTraceAcross(int row, int col, int agg, double value);
 
-    void SetBubbleBubbleBlock(int l, int j, double value);
+    void SetBubbleBubbleBlock(int agg_index, int l, int j, double value);
 
     void ResetEdgeCdofMarkers(int size);
 


### PR DESCRIPTION
This fixes errors in case where `RegisterRow` is not called and
`agg_index_` is not set in the `coarse_m_builder_` object.

Example command line that failed before this bug fix and now
runs:

```
./generalgraph --max-levels 3 --metis-agglomeration --coarse-factor 4 --num-part 30
```