### PR TITLE
Edge Projection operator

### DIFF
--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -812,7 +812,7 @@ mfem::SparseMatrix GraphCoarsen::BuildEdgeProjection(
     const int num_aggs = topology_.NumAggs();
     const int num_faces = topology_.NumFaces();
 
-    mfem::SparseMatrix Q_edge(face_edof.NumCols(), coarse_D_->NumCols());
+    mfem::SparseMatrix Q_edge(agg_edof.NumCols(), coarse_D_->NumCols());
     mfem::DenseMatrix Q_i;
 
     mfem::DenseMatrix sigma_f, sigma_f_T;;

--- a/src/GraphCoarsen.cpp
+++ b/src/GraphCoarsen.cpp
@@ -284,10 +284,10 @@ void GraphCoarsen::BuildAggregateFaceM(const mfem::Array<int>& face_edofs,
     }
 }
 
-void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
-                               std::vector<mfem::DenseMatrix>& vertex_target,
-                               const GraphSpace& coarse_space,
-                               mfem::SparseMatrix& Pedges)
+mfem::SparseMatrix GraphCoarsen::BuildPEdges(
+        std::vector<mfem::DenseMatrix>& edge_traces,
+        std::vector<mfem::DenseMatrix>& vertex_target,
+        const GraphSpace& coarse_space)
 {
     // put trace_extensions and bubble_functions in Pedges
     // the coarse dof numbering is as follows: first loop over each face, count
@@ -562,8 +562,7 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
             }
         }
     }
-    mfem::SparseMatrix newPedges(I, J, data, num_fine_edofs, num_coarse_edofs);
-    Pedges.Swap(newPedges);
+    mfem::SparseMatrix Pedges(I, J, data, num_fine_edofs, num_coarse_edofs);
 
     auto coef_mbuilder_ptr = dynamic_cast<CoefficientMBuilder*>(coarse_m_builder_.get());
     if (coef_mbuilder_ptr)
@@ -573,6 +572,8 @@ void GraphCoarsen::BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
         coef_mbuilder_ptr->BuildComponents(M_v, Pedges, face_edof,
                                            face_coarse_edof, agg_edof);
     }
+
+    return Pedges;
 }
 
 void GraphCoarsen::BuildCoarseW(const mfem::SparseMatrix& Pvertices)
@@ -601,9 +602,8 @@ void GraphCoarsen::BuildInterpolation(
         coarse_m_builder_ = make_unique<ElementMBuilder>();
     }
 
-    BuildPEdges(edge_traces, vertex_targets, coarse_space, Pedges);
-
-    BuildCoarseW(Pvertices);
+    auto Psigma = BuildPEdges(edge_traces, vertex_targets, coarse_space);
+    Pedges.Swap(Psigma);
 }
 
 unique_ptr<mfem::HypreParMatrix> GraphCoarsen::BuildCoarseEdgeDofTruedof(
@@ -777,6 +777,8 @@ MixedMatrix GraphCoarsen::BuildCoarseMatrix(GraphSpace coarse_graph_space,
                                             const MixedMatrix& fine_mgL,
                                             const mfem::SparseMatrix& Pvertices)
 {
+    BuildCoarseW(Pvertices);
+
     mfem::Vector coarse_const_rep(Pvertices.NumCols());
     Pvertices.MultTranspose(constant_rep_, coarse_const_rep);
 
@@ -794,6 +796,120 @@ MixedMatrix GraphCoarsen::BuildCoarseMatrix(GraphSpace coarse_graph_space,
     return MixedMatrix(std::move(coarse_graph_space), std::move(coarse_m_builder_),
                        std::move(coarse_D_), std::move(coarse_W_),
                        std::move(coarse_const_rep), std::move(agg_sizes), std::move(P_pwc));
+}
+
+mfem::SparseMatrix GraphCoarsen::BuildEdgeProjection(
+        const std::vector<mfem::DenseMatrix>& edge_traces,
+        const std::vector<mfem::DenseMatrix>& vertex_targets,
+        const GraphSpace& coarse_space)
+{
+    const mfem::SparseMatrix& agg_vdof = dof_agg_.agg_vdof_;
+    const mfem::SparseMatrix& agg_edof = dof_agg_.agg_edof_;
+    const mfem::SparseMatrix& face_edof = dof_agg_.face_edof_;
+    const mfem::SparseMatrix& agg_face = coarse_space.GetGraph().VertexToEdge();
+    const mfem::SparseMatrix& face_agg = topology_.face_Agg_;
+
+    const int num_aggs = topology_.NumAggs();
+    const int num_faces = topology_.NumFaces();
+
+    mfem::SparseMatrix Q_edge(face_edof.NumCols(), coarse_D_->NumCols());
+    mfem::DenseMatrix Q_i;
+
+    mfem::DenseMatrix sigma_f, sigma_f_T;;
+    mfem::DenseMatrix DT_one_pi_f_PV;
+
+    mfem::Vector PV_trace;
+    mfem::Vector one_rep;
+
+    mfem::Array<int> local_edofs, local_vdofs, faces, face_edofs;
+    mfem::Array<int> local_coarse_edofs, face_coarse_edofs;
+    int bubble_offset = coarse_space.EdgeToEDof().NumCols();
+
+    for (int agg = 0; agg < num_aggs; ++agg)
+    {
+        GetTableRowCopy(agg_edof, agg, local_edofs);
+        GetTableRow(agg_vdof, agg, local_vdofs);
+        GetTableRow(agg_face, agg, faces);
+
+        for (auto&& face : faces)
+        {
+            GetTableRow(face_edof, face, face_edofs);
+            local_edofs.Append(face_edofs);
+        }
+
+        auto Dloc = ExtractRowAndColumns(D_proc_, local_vdofs, local_edofs, col_map_);
+
+        auto& vert_targets = const_cast<mfem::DenseMatrix&>(vertex_targets[agg]);
+        Q_i.SetSize(Dloc.Width(), vert_targets.Width() - 1);
+        mfem::Vector column_in, column_out;
+        for (int j = 0; j < Q_i.Width(); ++j)
+        {
+            vert_targets.GetColumnReference(j + 1, column_in);
+            Q_i.GetColumnReference(j, column_out);
+            Dloc.MultTranspose(column_in, column_out);
+        }
+
+        local_coarse_edofs.SetSize(Q_i.Width());
+        std::iota(local_coarse_edofs.begin(), local_coarse_edofs.end(), bubble_offset);
+        Q_edge.AddSubMatrix(local_edofs, local_coarse_edofs, Q_i);
+        bubble_offset += Q_i.Width();
+    }
+
+    for (int face = 0; face < num_faces; ++face)
+    {
+        int agg = face_agg.GetRowColumns(face)[0];
+
+        GetTableRow(agg_vdof, agg, local_vdofs);
+        GetTableRow(face_edof, face, face_edofs);
+        GetTableRow(coarse_space.EdgeToEDof(), face, face_coarse_edofs);
+
+        auto& traces = const_cast<mfem::DenseMatrix&>(edge_traces[face]);
+        traces.GetColumnReference(0, PV_trace);
+
+        Q_i.SetSize(traces.NumRows(), traces.NumCols());
+
+        auto Dloc = ExtractRowAndColumns(D_proc_, local_vdofs, face_edofs, col_map_);
+        constant_rep_.GetSubVector(local_vdofs, one_rep);
+
+        mfem::Vector one_D(Q_i.Data(), Dloc.NumCols());
+        Dloc.MultTranspose(one_rep, one_D);
+
+        if (traces.NumCols() > 1)
+        {
+            sigma_f.UseExternalData(traces.Data() + traces.NumRows(),
+                                    traces.NumRows(),  traces.NumCols() - 1);
+
+            sigma_f_T.Transpose(sigma_f);
+            mfem::DenseMatrix sigma_f_prod(sigma_f.Width());
+            mfem::Mult(sigma_f_T, sigma_f, sigma_f_prod);
+            sigma_f_prod.Invert();
+
+            mfem::DenseMatrix pi_f(Q_i.Data()+Q_i.NumRows(),
+                                   Q_i.NumRows(), Q_i.NumCols() - 1);
+            mfem::Mult(sigma_f, sigma_f_prod, pi_f);
+
+            mfem::Vector pi_f_PV(pi_f.Width());
+            pi_f.MultTranspose(PV_trace, pi_f_PV);
+            DT_one_pi_f_PV.SetSize(one_D.Size(), pi_f_PV.Size());
+            mfem::MultVWt(one_D, pi_f_PV, DT_one_pi_f_PV);
+
+            pi_f -= DT_one_pi_f_PV;
+        }
+
+        double one_D_PV = smoothg::InnerProduct(one_D, PV_trace);
+        if (one_D_PV < 0)
+        {
+            one_D /= one_D_PV;
+        }
+        Q_i.SetCol(0, one_D);
+
+        Q_i *= -1.0;
+        Q_edge.AddSubMatrix(face_edofs, face_coarse_edofs, Q_i);
+    }
+
+    Q_edge.Finalize();
+
+    return smoothg::Transpose(Q_edge);
 }
 
 } // namespace smoothg

--- a/src/GraphCoarsen.hpp
+++ b/src/GraphCoarsen.hpp
@@ -112,9 +112,9 @@ public:
        @brief Build the projection operator from fine to coarse edge space
     */
     mfem::SparseMatrix BuildEdgeProjection(
-            const std::vector<mfem::DenseMatrix>& edge_traces,
-            const std::vector<mfem::DenseMatrix>& vertex_targets,
-            const GraphSpace& coarse_space);
+        const std::vector<mfem::DenseMatrix>& edge_traces,
+        const std::vector<mfem::DenseMatrix>& vertex_targets,
+        const GraphSpace& coarse_space);
 private:
     /**
        Construct coarse entities to coarse dofs table in the case when each dof

--- a/src/GraphCoarsen.hpp
+++ b/src/GraphCoarsen.hpp
@@ -107,6 +107,14 @@ public:
     MixedMatrix BuildCoarseMatrix(GraphSpace coarse_graph_space,
                                   const MixedMatrix& fine_mgL,
                                   const mfem::SparseMatrix& Pvertices);
+
+    /**
+       @brief Build the projection operator from fine to coarse edge space
+    */
+    mfem::SparseMatrix BuildEdgeProjection(
+            const std::vector<mfem::DenseMatrix>& edge_traces,
+            const std::vector<mfem::DenseMatrix>& vertex_targets,
+            const GraphSpace& coarse_space);
 private:
     /**
        Construct coarse entities to coarse dofs table in the case when each dof
@@ -185,18 +193,14 @@ private:
        interiors and contains the "bubbles". (The columns are in fact ordered as
        written above, but the rows are not.)
 
-       @param[in] edge_trace lives on faces, not aggregates
-       @param[in] vertex_target usually eigenvectors, lives on aggregate
-       @param[out] face_cdof is out, the face_cdof relation on coarse mesh
-                   (coarse faces, coarse dofs)
-       @param[out] Pedges the interpolation
-       @param[out] CM_el the coarse element mass matrices in case build_coarse_relation is true
-       @param[in] constant_rep representation of vertex constants on finer level
+       @param edge_trace lives on faces, not aggregates
+       @param vertex_target usually eigenvectors, lives on aggregate
+       @param coarse_space the coarse graph space
+       @return the interpolation matrix Pedges for edge space
     */
-    void BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
-                     std::vector<mfem::DenseMatrix>& vertex_target,
-                     const GraphSpace& coarse_space,
-                     mfem::SparseMatrix& Pedges);
+    mfem::SparseMatrix BuildPEdges(std::vector<mfem::DenseMatrix>& edge_traces,
+                                   std::vector<mfem::DenseMatrix>& vertex_target,
+                                   const GraphSpace& coarse_space);
 
     void BuildCoarseW(const mfem::SparseMatrix& Pvertices);
 

--- a/src/Mixed_GL_Coarsener.cpp
+++ b/src/Mixed_GL_Coarsener.cpp
@@ -51,6 +51,13 @@ void Mixed_GL_Coarsener::Interpolate(const mfem::BlockVector& coarse_vect,
     Pu_.Mult(coarse_vect.GetBlock(1), fine_vect.GetBlock(1));
 }
 
+void Mixed_GL_Coarsener::Project(const mfem::BlockVector& fine_vect,
+                                 mfem::BlockVector& coarse_vect) const
+{
+    Proj_sigma_.Mult(fine_vect.GetBlock(0), coarse_vect.GetBlock(0));
+    Pu_.MultTranspose(fine_vect.GetBlock(1), coarse_vect.GetBlock(1));
+}
+
 void Mixed_GL_Coarsener::Restrict(const mfem::Vector& fine_vect,
                                   mfem::Vector& coarse_vect) const
 {
@@ -61,6 +68,64 @@ void Mixed_GL_Coarsener::Interpolate(const mfem::Vector& coarse_vect,
                                      mfem::Vector& fine_vect) const
 {
     Pu_.Mult(coarse_vect, fine_vect);
+}
+
+void Mixed_GL_Coarsener::Project(const mfem::Vector& fine_vect,
+                                 mfem::Vector& coarse_vect) const
+{
+    Pu_.MultTranspose(fine_vect, coarse_vect);
+}
+
+void Mixed_GL_Coarsener::Debug_tests(const mfem::SparseMatrix& D) const
+{
+    mfem::Vector random_vec(Proj_sigma_.Height());
+    random_vec.Randomize();
+
+    mfem::Vector Psigma_rand(Psigma_.Height());
+    Psigma_.Mult(random_vec, Psigma_rand);
+    mfem::Vector out(Proj_sigma_.Height());
+    Proj_sigma_.Mult(Psigma_rand, out);
+
+    out -= random_vec;
+    double diff = out.Norml2();
+    if (diff >= 1e-10)
+    {
+        std::cerr << "|| rand - Proj_sigma_ * Psigma_ * rand || = " << diff
+                  << "\nEdge projection operator is not a projection!\n";
+    }
+    assert(diff < 1e-10);
+
+    random_vec.SetSize(Psigma_.Height());
+    random_vec.Randomize();
+
+    // Compute D * pi_sigma * random vector
+    mfem::Vector D_pi_sigma_rand(D.Height());
+    {
+        mfem::Vector Proj_sigma_rand(Proj_sigma_.Height());
+        Proj_sigma_.Mult(random_vec, Proj_sigma_rand);
+        mfem::Vector pi_sigma_rand(Psigma_.Height());
+        Psigma_.Mult(Proj_sigma_rand, pi_sigma_rand);
+        D.Mult(pi_sigma_rand, D_pi_sigma_rand);
+    }
+
+    // Compute pi_u * D * random vector
+    mfem::Vector pi_u_D_rand(D.Height());
+    {
+        mfem::Vector D_rand(D.Height());
+        D.Mult(random_vec, D_rand);
+        mfem::Vector PuT_D_rand(Pu_.Width());
+        Pu_.MultTranspose(D_rand, PuT_D_rand);
+        Pu_.Mult(PuT_D_rand, pi_u_D_rand);
+    }
+
+    pi_u_D_rand -= D_pi_sigma_rand;
+    diff = pi_u_D_rand.Norml2();
+    if (diff >= 1e-10)
+    {
+        std::cerr << "|| pi_u * D * rand - D * pi_sigma * rand || = " << diff
+                  << "\nCommutativity does not hold!\n";
+    }
+    assert(diff < 1e-10);
 }
 
 } // namespace smoothg

--- a/src/Mixed_GL_Coarsener.hpp
+++ b/src/Mixed_GL_Coarsener.hpp
@@ -73,10 +73,12 @@ public:
     // Mixed form
     void Restrict(const mfem::BlockVector& rhs, mfem::BlockVector& coarse_rhs) const;
     void Interpolate(const mfem::BlockVector& rhs, mfem::BlockVector& fine_rhs) const;
+    void Project(const mfem::BlockVector& rhs, mfem::BlockVector& coarse_rhs) const;
 
     // Primal form
     void Restrict(const mfem::Vector& rhs, mfem::Vector& coarse_rhs) const;
     void Interpolate(const mfem::Vector& rhs, mfem::Vector& fine_rhs) const;
+    void Project(const mfem::Vector& rhs, mfem::Vector& coarse_rhs) const;
 
 private:
     virtual MixedMatrix do_construct_coarse_subspace(
@@ -93,8 +95,13 @@ private:
     }
 
 protected:
+
+    /// Test if Proj_sigma_ * Psigma_ = identity
+    void Debug_tests(const mfem::SparseMatrix& D) const;
+
     mfem::SparseMatrix Psigma_;
     mfem::SparseMatrix Pu_;
+    mfem::SparseMatrix Proj_sigma_;
 }; // class Mixed_GL_Coarsener
 
 } // namespace smoothg

--- a/src/SpectralAMG_MGL_Coarsener.cpp
+++ b/src/SpectralAMG_MGL_Coarsener.cpp
@@ -60,6 +60,15 @@ MixedMatrix SpectralAMG_MGL_Coarsener::do_construct_coarse_subspace(
                                      coarse_space, param_.coarse_components,
                                      Pu_, Psigma_);
 
+    auto tmp = graph_coarsen.BuildEdgeProjection(local_edge_traces,
+                                                 local_spectral_vertex_targets,
+                                                 coarse_space);
+    Proj_sigma_.Swap(tmp);
+
+#ifdef SMOOTHG_DEBUG
+    Debug_tests(mgL.GetD());
+#endif
+
     return graph_coarsen.BuildCoarseMatrix(std::move(coarse_space), mgL, Pu_);
 }
 

--- a/src/Upscale.cpp
+++ b/src/Upscale.cpp
@@ -292,6 +292,36 @@ mfem::BlockVector Upscale::Restrict(int level, const mfem::BlockVector& x) const
     return coarse_vect;
 }
 
+void Upscale::Project(int level, const mfem::Vector& x, mfem::Vector& y) const
+{
+    assert(coarsener_[level - 1]);
+
+    coarsener_[level - 1]->Project(x, y);
+}
+
+mfem::Vector Upscale::Project(int level, const mfem::Vector& x) const
+{
+    mfem::Vector coarse_vect = GetVector(level);
+    Project(level, x, coarse_vect);
+
+    return coarse_vect;
+}
+
+void Upscale::Project(int level, const mfem::BlockVector& x, mfem::BlockVector& y) const
+{
+    assert(coarsener_[level - 1]);
+
+    coarsener_[level - 1]->Project(x, y);
+}
+
+mfem::BlockVector Upscale::Project(int level, const mfem::BlockVector& x) const
+{
+    mfem::BlockVector coarse_vect(GetBlockVector(level));
+    Project(level, x, coarse_vect);
+
+    return coarse_vect;
+}
+
 void Upscale::BlockOffsets(int level, mfem::Array<int>& offsets) const
 {
     GetMatrix(level).GetBlockOffsets().Copy(offsets);

--- a/src/Upscale.hpp
+++ b/src/Upscale.hpp
@@ -109,6 +109,14 @@ public:
     virtual void Restrict(int level, const mfem::BlockVector& x, mfem::BlockVector& y) const;
     virtual mfem::BlockVector Restrict(int level, const mfem::BlockVector& x) const;
 
+    /// Project vector at level-1 to level
+    virtual void Project(int level, const mfem::Vector& x, mfem::Vector& y) const;
+    virtual mfem::Vector Project(int level, const mfem::Vector& x) const;
+
+    /// Project vector at level-1 to level, in mixed form
+    virtual void Project(int level, const mfem::BlockVector& x, mfem::BlockVector& y) const;
+    virtual mfem::BlockVector Project(int level, const mfem::BlockVector& x) const;
+
     /// Get block offsets for sigma, u blocks of mixed form dofs
     virtual void BlockOffsets(int level, mfem::Array<int>& offsets) const;
 


### PR DESCRIPTION
Add the projection operator for edge space. Add also debug checks (when debug mode is on) on whether the `Proj_sigma_` is really a projection, and if the commutative property holds.

For the first check, given a random coefficient vector in the coarse space `random_vec`, its fine level representation is `Psigma_ * random_vec`, so `Proj_sigma_ * Psigma_ * random_vec` should return the same random vector. In other words, `Proj_sigma_ * Psigma_` should be an identity operator.

The second check is strange forward. Note that using the notation in the paper, pi^u = `Pu_` * `Pu_`^T, pi^sigma = `Psigma_` * `Proj_sigma_`