### PR TITLE
Fix/fine edge order

### DIFF
--- a/examples/stest.py
+++ b/examples/stest.py
@@ -709,9 +709,9 @@ def make_tests():
           "--shared-samples", "18",
           "--choose-samples", "0",
           "--seed", "1"],
-         {"coarse-variance":0.00016563124437545969,
-          "correction-variance":3.6669929731798261e-05,
-          "mlmc-estimate":-0.0075878586626547968}]
+         {"coarse-variance":0.00019821590592782775,
+          "correction-variance":5.532948306092317e-05,
+          "mlmc-estimate":-0.0059401689449150533}]
 
     tests["qoi-hb"] = \
         [["./qoi",
@@ -723,9 +723,9 @@ def make_tests():
           "--choose-samples", "0",
           "--hybridization",
           "--seed", "1"],
-         {"coarse-variance":0.00016563124437545969,
-          "correction-variance":3.6669929731798261e-05,
-          "mlmc-estimate":-0.0075878586626547968}]
+         {"coarse-variance":0.00019821590592782775,
+          "correction-variance":5.532948306092317e-05,
+          "mlmc-estimate":-0.0059401689449150533}]
 
     tests["qoi-one-level"] = \
         [["./qoi",

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -171,7 +171,10 @@ private:
     void SplitEdgeWeight(const mfem::Vector& edge_weight_local);
 
     /// For edges shared by two processes, multiply weight by 2
-    void FixSharedEdgeWeight(mfem::Vector& edge_weight_local);
+    void FixSharedEdgeWeight(const mfem::HypreParMatrix& edge_trueedge,
+                             mfem::Vector& edge_weight_local);
+
+    void ReorderEdges(const mfem::HypreParMatrix& edge_trueedge);
 
     mfem::Vector ReadVector(const std::string& filename, int global_size,
                             const mfem::Array<int>& local_to_global) const;

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -152,7 +152,8 @@ public:
     /// Indicate if the graph has "boundary"
     bool HasBoundary() const { return edge_bdratt_.Width() > 0; }
 private:
-    void Init(const mfem::SparseMatrix* edge_bdratt);
+    void Init(const mfem::HypreParMatrix& edge_trueedge,
+              const mfem::SparseMatrix* edge_bdratt);
 
     void Distribute(MPI_Comm comm,
                     const mfem::SparseMatrix& vertex_edge_global,

--- a/src/MatrixUtilities.cpp
+++ b/src/MatrixUtilities.cpp
@@ -616,6 +616,7 @@ mfem::HypreParMatrix* ParAdd(const mfem::HypreParMatrix& A_ref, const mfem::Hypr
     }
 
     /* hypre_ParCSRMatrixSetNumNonzeros(A); */
+    hypre_ParCSRMatrixSetNumNonzeros(C);
 
     /* Make sure that the first entry in each row is the diagonal one. */
     hypre_CSRMatrixReorder(hypre_ParCSRMatrixDiag(C));

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -396,6 +396,14 @@ void RescaleVector(const mfem::Vector& scaling, mfem::Vector& vec)
     }
 }
 
+void InvRescaleVector(const mfem::Vector& scaling, mfem::Vector& vec)
+{
+    for (int i = 0; i < vec.Size(); i++)
+    {
+        vec[i] /= scaling[i];
+    }
+}
+
 void GetElementColoring(mfem::Array<int>& colors, const mfem::SparseMatrix& el_el)
 {
     const int el0 = 0;
@@ -482,6 +490,57 @@ std::set<unsigned> FindNonZeroColumns(const mfem::SparseMatrix& mat)
     }
 
     return cols;
+}
+
+mfem::SparseMatrix EntityReorderMap(const mfem::HypreParMatrix& entity_trueentity,
+                                    const mfem::HypreParMatrix& entity_trueentity_entity)
+{
+    mfem::SparseMatrix entity_is_shared, diag, offd;
+    HYPRE_Int* colmap;
+    entity_trueentity_entity.GetOffd(entity_is_shared, colmap);
+    entity_trueentity.GetDiag(diag);
+    entity_trueentity.GetOffd(offd, colmap);
+    const HYPRE_Int entity_start = entity_trueentity.GetRowStarts()[0];
+
+    std::vector<int> sharedentity_to_entity;
+    sharedentity_to_entity.reserve(entity_is_shared.NumNonZeroElems());
+
+
+    std::map<int, int> trueentity_map;
+    for (int entity = 0; entity < entity_trueentity.NumRows(); ++entity)
+    {
+        if (entity_is_shared.RowSize(entity))
+        {
+            sharedentity_to_entity.push_back(entity);
+
+            if (diag.RowSize(entity)) // entity is owned
+            {
+                assert(diag.RowSize(entity) == 1);
+                trueentity_map[diag.GetRowColumns(entity)[0] + entity_start] = entity;
+            }
+            else
+            {
+                assert(offd.RowSize(entity) == 1);
+                trueentity_map[colmap[offd.GetRowColumns(entity)[0]]] = entity;
+            }
+        }
+    }
+
+    mfem::SparseMatrix entity_reorder_map(entity_trueentity.NumRows());
+
+    int count = 0;
+    auto it = trueentity_map.begin();
+    for (int entity = 0; entity < entity_trueentity.NumRows(); ++entity)
+    {
+        bool is_shared = entity_is_shared.RowSize(entity);
+        int row = is_shared ? sharedentity_to_entity[count++] : entity;
+        int col = is_shared ? (it++)->second : entity;
+        entity_reorder_map.Add(row, col, 1.0);
+    }
+
+    entity_reorder_map.Finalize();
+
+    return entity_reorder_map;
 }
 
 } // namespace smoothg

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -220,6 +220,9 @@ double PowerIterate(MPI_Comm comm, const mfem::Operator& A, mfem::Vector& result
 // Rescale vec by scaling: vec = diag(scaling) * vec
 void RescaleVector(const mfem::Vector& scaling, mfem::Vector& vec);
 
+// Rescale vec by scaling: vec = diag(scaling)^{-1} * vec
+void InvRescaleVector(const mfem::Vector& scaling, mfem::Vector& vec);
+
 /**
    @brief A SERIAL coloring algorithm marking distinct colors for adjacent elements
 
@@ -231,6 +234,10 @@ void RescaleVector(const mfem::Vector& scaling, mfem::Vector& vec);
 void GetElementColoring(mfem::Array<int>& colors, const mfem::SparseMatrix& el_el);
 
 std::set<unsigned> FindNonZeroColumns(const mfem::SparseMatrix& mat);
+
+mfem::SparseMatrix EntityReorderMap(const mfem::HypreParMatrix& entity_trueentity,
+                                    const mfem::HypreParMatrix& entity_trueentity_entity);
+
 
 } // namespace smoothg
 


### PR DESCRIPTION
Previously we have fixed the edge ordering (all local orderings follow true ordering) when we construct a coarse graph in `GraphTopology`. Turns out when we construct graph from `mfem::ParMesh`, the ordering sometimes has problem too. So this PR is to do the same fix as in `GraphTopology`.