### PR TITLE
Improve performance of HybridSolver

### DIFF
--- a/examples/finitevolume.cpp
+++ b/examples/finitevolume.cpp
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
     ess_attr = 1;
     if (lateral_pressure)
     {
-        ess_attr[0] = ess_attr[2] = 0;
+        ess_attr[nDimensions - 2] = ess_attr[nDimensions] = 0;
     }
 
     // Setting up finite volume discretization problem

--- a/examples/pde.hpp
+++ b/examples/pde.hpp
@@ -964,7 +964,7 @@ void SPE10Problem::MakeRHS()
     {
         mfem::Array<int> nat_negative_one(ess_attr_.Size());
         nat_negative_one = 0;
-        nat_negative_one[0] = 1;
+        nat_negative_one[pmesh_->Dimension() - 2] = 1;
 
         mfem::ConstantCoefficient negative_one(-1.0);
         mfem::RestrictedCoefficient pinflow_coeff(negative_one, nat_negative_one);

--- a/src/Hierarchy.cpp
+++ b/src/Hierarchy.cpp
@@ -90,7 +90,8 @@ void Hierarchy::MakeSolver(int level, const UpscaleParameters& param)
     if (param.hybridization) // Hybridization solver
     {
         SAAMGeParam* sa_param = level ? param.saamge_param : nullptr;
-        solvers_[level].reset(new HybridSolver(GetMatrix(level), ess_attr_, 0, sa_param));
+        solvers_[level].reset(new HybridSolver(GetMatrix(level), ess_attr_,
+                                               param.rescale_iter, sa_param));
     }
     else // L2-H1 block diagonal preconditioner
     {
@@ -426,7 +427,7 @@ void Hierarchy::Debug_tests(int level) const
 
     out -= random_vec;
     double diff = mfem::ParNormlp(out, 2, comm_) / mfem::ParNormlp(random_vec, 2, comm_);
-    if (diff >= error_tolerance)
+    if (myid_ == 0 && diff >= error_tolerance)
     {
         std::cerr << "|| rand - Proj_sigma_ * Psigma_ * rand || / || rand || = " << diff
                   << "\nWarning: Edge projection operator is not a projection!\n";
@@ -456,7 +457,7 @@ void Hierarchy::Debug_tests(int level) const
 
     pi_u_D_rand -= D_pi_sigma_rand;
     diff = mfem::ParNormlp(pi_u_D_rand, 2, comm_) / mfem::ParNormlp(random_vec, 2, comm_);
-    if (diff >= error_tolerance)
+    if (myid_ == 0 && diff >= error_tolerance)
     {
         std::cerr << "|| pi_u * D * rand - D * pi_sigma * rand || / || rand || = "
                   << diff << "\nWarning: commutativity does not hold!\n";

--- a/src/HybridSolver.cpp
+++ b/src/HybridSolver.cpp
@@ -515,7 +515,7 @@ void HybridSolver::ComputeScaledHybridSystem(const mfem::HypreParMatrix& H)
         mfem::HypreSmoother prec_scale(const_cast<mfem::HypreParMatrix&>(H));
 
         mfem::Vector zeros(H.Height());
-        zeros = 1e-8;
+        zeros = 0.0;
         diagonal_scaling_.SetSize(H.Height());
         diagonal_scaling_ = 1.0;
 

--- a/src/HybridSolver.cpp
+++ b/src/HybridSolver.cpp
@@ -35,8 +35,7 @@ HybridSolver::HybridSolver(const MixedMatrix& mgL,
                            const SAAMGeParam* saamge_param)
     :
     MixedLaplacianSolver(mgL.GetComm(), mgL.BlockOffsets(), mgL.CheckW()),
-    D_(mgL.GetD()),
-    W_(mgL.GetW()),
+    mgL_(mgL),
     rescale_iter_(rescale_iter),
     saamge_param_(saamge_param)
 {
@@ -50,9 +49,6 @@ HybridSolver::HybridSolver(const MixedMatrix& mgL,
     }
 
     const GraphSpace& graph_space = mgL.GetGraphSpace();
-
-    Agg_vertexdof_.MakeRef(graph_space.VertexToVDof());
-    Agg_edgedof_.MakeRef(graph_space.VertexToEDof());
 
     Init(graph_space.EdgeToEDof(), mbuilder->GetElementMatrices(),
          graph_space.EDofToTrueEDof(), graph_space.EDofToBdrAtt());
@@ -79,8 +75,7 @@ void HybridSolver::Init(
     chrono.Clear();
     chrono.Start();
 
-    nAggs_ = Agg_edgedof_.Height();
-    num_edge_dofs_ = Agg_edgedof_.Width();
+    nAggs_ = mgL_.GetGraph().NumVertices();
 
     // Set the size of the Hybrid_el_, AinvCT, Ainv_f_, these are all local
     // matrices and vector for each element
@@ -121,11 +116,14 @@ void HybridSolver::CreateMultiplierRelations(
     // face, a Lagrange multiplier dof associated with the edge dof is created
     num_multiplier_dofs_ = face_edgedof.Width();
 
-    int* i_edgedof_multiplier = new int[num_edge_dofs_ + 1];
+    const auto& Agg_edgedof = mgL_.GetGraphSpace().VertexToEDof();
+    const int num_edge_dofs = Agg_edgedof.Width();
+
+    int* i_edgedof_multiplier = new int[num_edge_dofs + 1];
     std::iota(i_edgedof_multiplier,
               i_edgedof_multiplier + num_multiplier_dofs_ + 1, 0);
     std::fill_n(i_edgedof_multiplier + num_multiplier_dofs_ + 1,
-                num_edge_dofs_ - num_multiplier_dofs_,
+                num_edge_dofs - num_multiplier_dofs_,
                 i_edgedof_multiplier[num_multiplier_dofs_]);
 
     int* j_edgedof_multiplier = new int[num_multiplier_dofs_];
@@ -135,13 +133,13 @@ void HybridSolver::CreateMultiplierRelations(
     std::fill_n(data_edgedof_multiplier, num_multiplier_dofs_, 1.0);
     mfem::SparseMatrix edgedof_multiplier(
         i_edgedof_multiplier, j_edgedof_multiplier,
-        data_edgedof_multiplier, num_edge_dofs_, num_multiplier_dofs_);
+        data_edgedof_multiplier, num_edge_dofs, num_multiplier_dofs_);
     mfem::SparseMatrix mult_edof(smoothg::Transpose(edgedof_multiplier) );
 
     mfem::Array<int> j_array(mult_edof.GetJ(), mult_edof.NumNonZeroElems());
     j_array.Copy(multiplier_to_edof_);
 
-    mfem::SparseMatrix Agg_m_tmp(smoothg::Mult(Agg_edgedof_, edgedof_multiplier));
+    mfem::SparseMatrix Agg_m_tmp(smoothg::Mult(Agg_edgedof, edgedof_multiplier));
     Agg_multiplier_.Swap(Agg_m_tmp);
 
     GenerateOffsets(comm_, num_multiplier_dofs_, multiplier_start_);
@@ -159,23 +157,30 @@ mfem::SparseMatrix HybridSolver::AssembleHybridSystem(
 {
     mfem::SparseMatrix H_proc(num_multiplier_dofs_);
 
-    const int map_size = std::max(num_edge_dofs_, Agg_vertexdof_.Width());
+    const auto& Agg_vertexdof = mgL_.GetGraphSpace().VertexToVDof();
+    const auto& Agg_edgedof = mgL_.GetGraphSpace().VertexToEDof();
+
+    const int map_size = std::max(Agg_edgedof.Width(), Agg_vertexdof.Width());
     mfem::Array<int> edof_global_to_local_map(map_size);
     edof_global_to_local_map = -1;
-    mfem::Array<bool> edge_marker(num_edge_dofs_);
-    edge_marker = true;
+    std::vector<bool> edge_marker(Agg_edgedof.Width(), true);
 
     mfem::SparseMatrix edof_IsOwned = GetDiag(*multiplier_d_td_);
 
-    mfem::DenseMatrix DlocT, ClocT, Aloc, CMinvDT, DMinvCT, CMDADMC;
+    const int scaling_size = rescale_iter_ < 0 ? H_proc.NumRows() : 0;
+    mfem::Vector CCT_diag(scaling_size), CDT1(scaling_size);
+    CCT_diag = 0.0;
+    CDT1 = 0.0;
 
+    mfem::DenseMatrix DlocT, ClocT, Aloc, CMinvDT, DMinvCT, CMDADMC;
+    mfem::Vector one;
     mfem::DenseMatrixInverse Mloc_solver;
     for (int iAgg = 0; iAgg < nAggs_; ++iAgg)
     {
         // Extracting the size and global numbering of local dof
         mfem::Array<int> local_vertexdof, local_edgedof, local_multiplier;
-        GetTableRow(Agg_vertexdof_, iAgg, local_vertexdof);
-        GetTableRow(Agg_edgedof_, iAgg, local_edgedof);
+        GetTableRow(Agg_vertexdof, iAgg, local_vertexdof);
+        GetTableRow(Agg_edgedof, iAgg, local_edgedof);
         GetTableRow(Agg_multiplier_, iAgg, local_multiplier);
 
         const int nlocal_vertexdof = local_vertexdof.Size();
@@ -188,7 +193,7 @@ mfem::SparseMatrix HybridSolver::AssembleHybridSystem(
             edof_global_to_local_map[local_edgedof[i]] = i;
 
         // Extract Dloc as a sparse submatrix of D_
-        auto Dloc = ExtractRowAndColumns(D_, local_vertexdof, local_edgedof,
+        auto Dloc = ExtractRowAndColumns(mgL_.GetD(), local_vertexdof, local_edgedof,
                                          edof_global_to_local_map, false);
 
         // Fill DlocT as a dense matrix of Dloc^T
@@ -247,15 +252,15 @@ mfem::SparseMatrix HybridSolver::AssembleHybridSystem(
         // Compute Aloc = DMinvDT = Dloc * MinvDT
         MultSparseDense(Dloc, MinvDT_i, Aloc);
 
-        if (W_.Width())
+        if (mgL_.GetW().Width())
         {
             mfem::DenseMatrix Wloc(nlocal_vertexdof, nlocal_vertexdof);
-            auto& W_ref = const_cast<mfem::SparseMatrix&>(W_);
+            auto& W_ref = const_cast<mfem::SparseMatrix&>(mgL_.GetW());
             W_ref.GetSubMatrix(local_vertexdof, local_vertexdof, Wloc);
             Aloc += Wloc;
         }
 
-        // Compute DMinvCT Dloc * MinvCT
+        // Compute DMinvCT = Dloc * MinvCT
         MultSparseDense(Dloc, MinvCT_i, DMinvCT);
 
         // Compute the LU factorization of Aloc and Ainv_ * DMinvCT
@@ -283,6 +288,44 @@ mfem::SparseMatrix HybridSolver::AssembleHybridSystem(
 
         // Add contribution of the element matrix to the global system
         H_proc.AddSubMatrix(local_multiplier, local_multiplier, Hybrid_el_[iAgg]);
+
+        // Save CCT and CDT1
+        if (scaling_size > 0)
+        {
+            mfem::DenseMatrix CCT(nlocal_multiplier);
+            MultSparseDense(Cloc, ClocT, CCT);
+            mfem::Vector CCT_diag_local;
+            CCT.GetDiag(CCT_diag_local);
+
+            const_rep_->GetSubVector(local_vertexdof, one);
+            mfem::Vector DTone(nlocal_edgedof);
+            Dloc.MultTranspose(one, DTone);
+
+            mfem::Vector CDT1_local(nlocal_multiplier);
+            Cloc.Mult(DTone, CDT1_local);
+
+            for (int i = 0; i < nlocal_multiplier; ++i)
+            {
+                CCT_diag[local_multiplier[i]] += CCT_diag_local[i];
+                CDT1[local_multiplier[i]] += CDT1_local[i];
+            }
+        }
+    }
+
+    // Assemble global rescaling vector (CC^T)^{-1}CD^T 1
+    if (scaling_size)
+    {
+        mfem::Vector CCT_diag_global(multiplier_d_td_->NumCols());
+        multiplier_td_d_->Mult(CCT_diag, CCT_diag_global);
+
+        mfem::Vector CDT1_global(multiplier_d_td_->NumCols());
+        multiplier_td_d_->Mult(CDT1, CDT1_global);
+
+        diagonal_scaling_.SetSize(multiplier_d_td_->NumCols());
+        for (int i = 0; i < diagonal_scaling_.Size(); ++i)
+        {
+            diagonal_scaling_[i] = CDT1_global[i] / CCT_diag_global[i];
+        }
     }
 
     return H_proc;
@@ -376,6 +419,7 @@ void HybridSolver::RHSTransform(const mfem::BlockVector& OriginalRHS,
                                 mfem::Vector& HybridRHS) const
 {
     const mfem::Vector& OriginalRHS_block2(OriginalRHS.GetBlock(1));
+    const auto& Agg_vertexdof = mgL_.GetGraphSpace().VertexToVDof();
 
     HybridRHS = 0.;
 
@@ -384,7 +428,7 @@ void HybridSolver::RHSTransform(const mfem::BlockVector& OriginalRHS,
     {
         // Extracting the size and global numbering of local dof
         mfem::Array<int> local_vertexdof, local_multiplier;
-        GetTableRow(Agg_vertexdof_, iAgg, local_vertexdof);
+        GetTableRow(Agg_vertexdof, iAgg, local_vertexdof);
         GetTableRow(Agg_multiplier_, iAgg, local_multiplier);
 
         int nlocal_vertexdof = local_vertexdof.Size();
@@ -410,6 +454,9 @@ void HybridSolver::RHSTransform(const mfem::BlockVector& OriginalRHS,
 void HybridSolver::RecoverOriginalSolution(const mfem::Vector& HybridSol,
                                            mfem::BlockVector& RecoveredSol) const
 {
+    const auto& Agg_vertexdof = mgL_.GetGraphSpace().VertexToVDof();
+    const auto& Agg_edgedof = mgL_.GetGraphSpace().VertexToEDof();
+
     // Recover the solution of the original system from multiplier mu, i.e.,
     // [u;p] = [f;g] - [M B^T;B 0]^-1[C 0]^T * mu
     // This procedure is done locally in each element
@@ -423,8 +470,8 @@ void HybridSolver::RecoverOriginalSolution(const mfem::Vector& HybridSol,
     {
         // Extracting the size and global numbering of local dof
         mfem::Array<int> local_vertexdof, local_edgedof, local_multiplier;
-        GetTableRow(Agg_vertexdof_, iAgg, local_vertexdof);
-        GetTableRow(Agg_edgedof_, iAgg, local_edgedof);
+        GetTableRow(Agg_vertexdof, iAgg, local_vertexdof);
+        GetTableRow(Agg_edgedof, iAgg, local_edgedof);
         GetTableRow(Agg_multiplier_, iAgg, local_multiplier);
 
         int nlocal_vertexdof = local_vertexdof.Size();
@@ -463,22 +510,28 @@ void HybridSolver::RecoverOriginalSolution(const mfem::Vector& HybridSol,
 
 void HybridSolver::ComputeScaledHybridSystem(const mfem::HypreParMatrix& H)
 {
-    mfem::HypreSmoother prec_scale(const_cast<mfem::HypreParMatrix&>(H));
+    if (rescale_iter_ > 0)
+    {
+        mfem::HypreSmoother prec_scale(const_cast<mfem::HypreParMatrix&>(H));
 
-    mfem::Vector zeros(H.Height());
-    zeros = 1e-8;
-    diagonal_scaling_.SetSize(H.Height());
-    diagonal_scaling_ = 1.0;
+        mfem::Vector zeros(H.Height());
+        zeros = 1e-8;
+        diagonal_scaling_.SetSize(H.Height());
+        diagonal_scaling_ = 1.0;
 
-    mfem::CGSolver cg_scale(comm_);
-    cg_scale.SetMaxIter(rescale_iter_);
-    cg_scale.SetPreconditioner(prec_scale);
-    cg_scale.SetOperator(H);
-    cg_scale.Mult(zeros, diagonal_scaling_);
+        mfem::SLISolver sli(comm_);
+        sli.SetMaxIter(rescale_iter_);
+        sli.SetPreconditioner(prec_scale);
+        sli.SetOperator(H);
+        sli.Mult(zeros, diagonal_scaling_);
+    }
 
-    auto Scale = VectorToMatrix(diagonal_scaling_);
-    mfem::HypreParMatrix pScale(comm_, H.N(), H.GetColStarts(), &Scale);
-    H_.reset(smoothg::Mult(pScale, H, pScale));
+    if (num_multiplier_dofs_ == mgL_.GetGraph().NumEdges())
+    {
+        auto Scale = VectorToMatrix(diagonal_scaling_);
+        mfem::HypreParMatrix pScale(comm_, H.N(), H.GetColStarts(), &Scale);
+        H_.reset(smoothg::Mult(pScale, H, pScale));
+    }
 }
 
 void HybridSolver::BuildSpectralAMGePreconditioner()
@@ -552,7 +605,7 @@ void HybridSolver::BuildParallelSystemAndSolver(mfem::SparseMatrix& H_proc)
 
     H_elim_.reset(H_->EliminateRowsCols(ess_true_multipliers_));
 
-    if (rescale_iter_ > 0 && !saamge_param_)
+    if (std::abs(rescale_iter_) > 0 && !saamge_param_)
     {
         ComputeScaledHybridSystem(*H_);
     }
@@ -582,11 +635,40 @@ void HybridSolver::BuildParallelSystemAndSolver(mfem::SparseMatrix& H_proc)
         {
             BuildSpectralAMGePreconditioner();
         }
-        else
+        else if (num_multiplier_dofs_ == mgL_.GetGraph().NumEdges())
         {
             auto temp_prec = make_unique<mfem::HypreBoomerAMG>(*H_);
             temp_prec->SetPrintLevel(0);
             prec_ = std::move(temp_prec);
+        }
+        else
+        {
+            std::unique_ptr<mfem::SparseMatrix> te_tm;
+            {
+                const auto& edge_trueedge = mgL_.GetGraph().EdgeToTrueEdge();
+                const auto& edge_edof = mgL_.GetGraphSpace().EdgeToEDof();
+                mfem::SparseMatrix e_te_diag = GetDiag(edge_trueedge);
+                mfem::SparseMatrix m_tm_diag = GetDiag(*multiplier_d_td_);
+                te_tm.reset(RAP(e_te_diag, edge_edof, m_tm_diag));
+            }
+
+            mfem::SparseMatrix PV_map(te_tm->NumCols(), te_tm->NumRows());
+
+            std::vector<mfem::Array<int>> local_dofs(te_tm->NumRows());
+            for (int i = 0; i < te_tm->NumRows(); ++i)
+            {
+                GetTableRow(*te_tm, i, local_dofs[i]);
+                PV_map.Set(local_dofs[i][0], i, 1.0);
+            }
+            PV_map.Finalize();
+
+            if (diagonal_scaling_.Size() > 0)
+            {
+                PV_map.ScaleRows(diagonal_scaling_);
+                diagonal_scaling_.SetSize(0);
+            }
+
+            prec_ = make_unique<AuxSpacePrec>(*H_, std::move(PV_map), local_dofs);
         }
         cg_->SetPreconditioner(*prec_);
     }
@@ -677,6 +759,81 @@ void HybridSolver::SetAbsTol(double atol)
     MixedLaplacianSolver::SetAbsTol(atol);
 
     cg_->SetAbsTol(atol_);
+}
+
+AuxSpacePrec::AuxSpacePrec(mfem::HypreParMatrix& op, mfem::SparseMatrix aux_map,
+                           const std::vector<mfem::Array<int>>& loc_dofs)
+    : mfem::Solver(op.NumRows(), false),
+      local_dofs_(loc_dofs.size()),
+      local_ops_(local_dofs_.size()),
+      local_solvers_(local_dofs_.size()),
+      op_(op),
+      aux_map_(std::move(aux_map))
+{
+    op.GetDiag(op_diag_);
+    for (unsigned int i = 0; i < local_dofs_.size(); ++i)
+    {
+        loc_dofs[i].Copy(local_dofs_[i]);
+        local_ops_[i].SetSize(local_dofs_[i].Size());
+        op_diag_.GetSubMatrix(local_dofs_[i], local_dofs_[i], local_ops_[i]);
+        mfem::DenseMatrixInverse local_solver_i(local_ops_[i]);
+        local_solver_i.GetInverseMatrix(local_solvers_[i]);
+    }
+
+
+    // Set up auxilary space solver
+    mfem::Array<int> adof_starts;
+    GenerateOffsets(op.GetComm(), aux_map_.NumCols(), adof_starts);
+    int num_global_adofs = adof_starts.Last();
+    mfem::HypreParMatrix par_aux_map(op.GetComm(), op.N(), num_global_adofs,
+                                     op.ColPart(), adof_starts, &aux_map_);
+    aux_op_.reset(smoothg::RAP(op, par_aux_map));
+    aux_op_->CopyRowStarts();
+    aux_op_->CopyColStarts();
+
+    aux_solver_ = make_unique<mfem::HypreBoomerAMG>(*aux_op_);
+    aux_solver_->SetPrintLevel(-1);
+}
+
+void AuxSpacePrec::Mult(const mfem::Vector& x, mfem::Vector& y) const
+{
+    y = 0.0;
+
+    mfem::Vector x_aux, y_aux, residual(x), correction(y.Size());
+    correction = 0.0;
+
+    Smoothing(x, y);
+
+    op_.Mult(-1.0, y, 1.0, residual);
+
+    x_aux.SetSize(aux_map_.NumCols());
+    y_aux.SetSize(aux_map_.NumCols());
+    x_aux = 0.0;
+    y_aux = 0.0;
+    aux_map_.MultTranspose(residual, x_aux);
+    aux_solver_->Mult(x_aux, y_aux);
+    aux_map_.Mult(y_aux, correction);
+
+    op_.Mult(-1.0, correction, 1.0, residual);
+    y += correction;
+
+    Smoothing(residual, correction);
+
+    y += correction;
+}
+
+void AuxSpacePrec::Smoothing(const mfem::Vector& x, mfem::Vector& y) const
+{
+    // block Jacobi
+    y = 0.0;
+    mfem::Vector x_local, y_local;
+    for (unsigned int i = 0; i < local_dofs_.size(); ++i)
+    {
+        x.GetSubVector(local_dofs_[i], x_local);
+        y_local.SetSize(x_local.Size());
+        local_solvers_[i].Mult(x_local, y_local);
+        y.AddElementVector(local_dofs_[i], y_local);
+    }
 }
 
 } // namespace smoothg

--- a/src/HybridSolver.hpp
+++ b/src/HybridSolver.hpp
@@ -88,15 +88,17 @@ public:
        @param mgL Mixed matrices for the graph Laplacian in the fine level
        @param face_bdrattr Boundary edge to boundary attribute table
        @param ess_edge_dofs An array indicating essential edge dofs
-       @param rescale_iter number of iterations to compute diagonal scaling
-              vector for hybridized system. No rescaling if set to 0.
+       @param rescale_iter if negative, a rescaling vector for the hybridized
+              system will be computed based on SISC, 41(3), B425–B447 Prop. 4.3;
+              if positive, the rescaling vector will be computed by performing
+              rescale_iter smoothing steps to H; no rescaling if set to 0.
        @param saamge_param SAAMGe parameters. Use SAAMGe as preconditioner for
               hybridized system if saamge_param is not nullptr, otherwise
               BoomerAMG is used instead.
     */
     HybridSolver(const MixedMatrix& mgL,
                  const mfem::Array<int>* ess_attr = nullptr,
-                 const int rescale_iter = 0,
+                 const int rescale_iter = -1,
                  const SAAMGeParam* saamge_param = nullptr);
 
     virtual ~HybridSolver();

--- a/src/HybridSolver.hpp
+++ b/src/HybridSolver.hpp
@@ -217,17 +217,16 @@ private:
 };
 
 
-/// assuming symmetric problems
+/// Auxiliary space preconditioner, smoother is block Jacobi (on each edge)
 class AuxSpacePrec : public mfem::Solver
 {
 public:
-    /// dofs are in true dofs numbering, coarse_map: coarse to fine
+    /// dofs are in true dofs numbering, aux_map: map to span of PV vectors
     AuxSpacePrec(mfem::HypreParMatrix& op, mfem::SparseMatrix aux_map,
                  const std::vector<mfem::Array<int>>& loc_dofs);
 
     virtual void Mult(const mfem::Vector& x, mfem::Vector& y) const;
     virtual void SetOperator(const mfem::Operator& op) {}
-
 private:
 
     void Smoothing(const mfem::Vector& x, mfem::Vector& y) const;

--- a/src/LocalMixedGraphSpectralTargets.hpp
+++ b/src/LocalMixedGraphSpectralTargets.hpp
@@ -67,6 +67,7 @@ struct SAAMGeParam
    @param trace_method methods for getting edge trace samples
    @param hybridization use hybridization as solver
    @param coefficient use coarse coefficient rescaling construction
+   @param rescale_iter number of iteration to compute scaling in hybridization
    @param saamge_param SAAMGe paramters, use SAAMGe as preconditioner for
           coarse hybridized system if saamge_param is not nullptr
 */
@@ -82,6 +83,7 @@ public:
     bool hybridization;
     bool coarse_components;
     int coarse_factor;
+    int rescale_iter;
     SAAMGeParam* saamge_param;
     // possibly also boundary condition information?
 
@@ -94,6 +96,7 @@ public:
         hybridization(false),
         coarse_components(false),
         coarse_factor(64),
+        rescale_iter(-1),
         saamge_param(NULL)
     {}
 
@@ -117,6 +120,8 @@ public:
                        "--no-coarse-components", "Store trace, bubble components of coarse M.");
         args.AddOption(&coarse_factor, "--coarse-factor", "--coarse-factor",
                        "Coarsening factor for metis agglomeration.");
+        args.AddOption(&rescale_iter, "--rescale-iter", "--rescale-iter",
+                       "Number of iteration to compute rescale vector in hybridization.");
     }
 };
 


### PR DESCRIPTION
Two improvements: 
1. add a way to automatically compute a good scaling vector based on SIAM J. Sci. Comput., 41(3), B425–B447. This works well when there is only one "edge dof" per edge.

2. when there is more that one "edge dof" per edge in the upscaled problem, the scaling vector in 1 most likely will generate bunch of zeros (because of the way we construct coarse space, "divergence" of some of them are zero). So in this case, project the problem to the space of PV vectors (where we can solve efficiently because of point 1), and supplement this with some smoothing (block Jacobi) on the original problem.

Here are some results with the new solver:

two example runs on `master`:
```
mpirun -n 4 ./finitevolume -ma -s 84 -t 1 -m 5 -hb
Level 1 Solve Time:         0.0503802
Level 1 Solve Iterations:   213
```
and 
```
mpirun -n 4 ./finitevolume -ma -d 3 -t 1 -m 8 -hb
Level 1 Solve Time:         165.585
Level 1 Solve Iterations:   3496 
```

The same example on `feature/better-hybrid-solver`:
```
mpirun -n 4 ./finitevolume -ma -s 84 -t 1 -m 5 -hb
Level 1 Solve Time:         0.00631809
Level 1 Solve Iterations:   23
```
and 
```
mpirun -n 4 ./finitevolume -ma -d 3 -t 1 -m 8 -hb
Level 1 Solve Time:         0.620253
Level 1 Solve Iterations:   24
```




